### PR TITLE
Update contact details on code of conduct page

### DIFF
--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -13,9 +13,6 @@
         </header>
         <main>
             <h2>Code of Conduct</h2>
-            <blockquote>
-                <p>Note: While The Collab Lab team is forming, violations of the Code of Conduct may be directed to <a href="mailto:andrew@hedges.name">Andrew Hedges</a>. Once we have some volunteers for it in place, he will be replaced by a proper Response Team. Thanks for your understanding.</p>
-            </blockquote>
             <p>The Collab Lab is dedicated to providing a harassment-free experience for everyone. We do not tolerate harassment of participants in any form.</p>
             <p>This code of conduct applies to all Collab Lab spaces, including but not limited to our GitHub and Slack teams, both online and off. Anyone who violates this code of conduct may be sanctioned or expelled from these spaces at the discretion of the RESPONSE TEAM.</p>
             <p>Some Collab Lab spaces may have additional rules in place, which will be made clearly available to participants. Participants are responsible for knowing and abiding by these rules.</p>
@@ -40,10 +37,16 @@
             </ul>
             <p>The Collab Lab prioritizes marginalized people’s safety over privileged people’s comfort. RESPONSE TEAM reserves the right not to act on complaints regarding the following: “Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia”.</p>
             <h2>Reporting</h2>
-            <p>If you are being harassed by a member of The Collab Lab, notice that someone else is being harassed, or have any other concerns, please contact the RESPONSE TEAM via DM. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.</p>
+            <p>If you are being harassed by a member of The Collab Lab, notice that someone else is being harassed, or have any other concerns, please contact the RESPONSE TEAM immediately. If the person who is harassing you is on the team, they will recuse themselves from handling your incident. We will respond as promptly as we can.</p>
             <p>This code of conduct applies to Collab Lab spaces, but if you are being harassed by a member of The Collab Lab outside our spaces, we still want to know about it. We will take all good-faith reports of harassment by Collab Lab members, especially Founder Andrew Hedges, seriously. This includes harassment outside our spaces and harassment that took place at any point in time. The abuse team reserves the right to exclude people from The Collab Lab based on their past behavior, including behavior outside Collab Lab spaces and behavior towards people who are not in The Collab Lab.</p>
             <p>In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.</p>
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
+            <p>You can report violations in the following ways:</p>
+            <ul>
+                <li>Email <a href="mailto:stacietaylorcima@gmail.com">Stacie Taylor-Cima</a></li>
+                <li>Direct message @stacie in the Collab Lab Slack workspace</li>
+                <li>Private message <a href="https://twitter.com/the_real_stacie">@the_real_stacie</a> on Twitter</li>
+            </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
             <p>If a participant engages in harassing behavior, RESPONSE TEAM may take any action they deem appropriate, up to and including expulsion from all Collab Lab spaces and identification of the participant as a harasser to other Collab Lab members or the general public.</p>


### PR DESCRIPTION
The actual website code of conduct page has been updated to include 3 ways to contact Stacie Taylor-Cima to report violations of the code of conduct.