### PR TITLE
Update color on block quote's link hover state

### DIFF
--- a/build/assets/styles.css
+++ b/build/assets/styles.css
@@ -51,6 +51,7 @@ blockquote {
     }
         blockquote a:hover {
             color: white;
+            border-bottom: solid 1px white;
         }
 
 .hang-it {


### PR DESCRIPTION
## Description

When hovering over the link in block quote, the underline is blue which is only a 1.47:1 contrast from the dark background color. This fails to meet accessibility requirements. (See color test [here](https://webaim.org/resources/contrastchecker/?fcolor=0000FF&bcolor=333333).)

Changing that underline to white meets accessibility color contrast requirements... and just looks a lot nicer.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :hammer: Refactoring       |

## Before / After

Before: 
![Screenshot of blockquote link on hover before changes. Underline is blue and inaccessible.](https://zappy.zapier.com/104BFC0E-8C94-4785-B235-7B4605F7D440.png)

After: 
![Screenshot of blockquote link on hover after changes. Underline is blue and inaccessible.](https://zappy.zapier.com/30B57430-1EE8-41F6-A296-838A2A669142.png)

## Testing Steps / QA Criteria

* Hover over blockquote's link and make sure the underline is white. 
