### PR TITLE
Enlargenate the header a little and make sub-page more like a breadcrumb

### DIFF
--- a/build/assets/styles.css
+++ b/build/assets/styles.css
@@ -15,6 +15,7 @@ header, main, footer {
 
 header {}
     header h1 {
+        font-size: 2.5rem;
         margin-bottom: 0.5rem;
     }
     header h2 {

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -3,13 +3,16 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>The Collab Lab</title>
+        <title>Code of Conduct / The Collab Lab</title>
         <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext">
         <link rel="stylesheet" href="/assets/styles.css">
     </head>
     <body>
         <header>
-            <h1><a href="/">The Collab Lab</a></h1>
+            <h1>
+                <a href="/">The Collab Lab</a> /
+                Code of Conduct
+            </h1>
         </header>
         <main>
             <h2>Code of Conduct</h2>


### PR DESCRIPTION
This is mostly a stylistic tweak to set the top-level header apart from the page content. Also made the sub-page header more like a breadcrumb nav to make it more apparent where the user is and how to get back to the main page.

## Before:
<img width="626" alt="image" src="https://user-images.githubusercontent.com/4306/68415950-55624c80-0148-11ea-9889-00088b024b78.png">

## After:
<img width="617" alt="image" src="https://user-images.githubusercontent.com/4306/68415921-48455d80-0148-11ea-8628-9d07e7069b43.png">
