### PR TITLE
Update CoC email to reflect new the-collab-lab.codes address

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -39,7 +39,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 You can report violations in the following ways:
 
-- Email [Stacie Taylor-Cima](mailto:stacietaylorcima@gmail.com)
+- Email [Stacie Taylor-Cima](mailto:code-of-conduct@the-collab-lab.codes)
 - Direct message @stacie in the Collab Lab Slack workspace
 - Private message [@the_real_stacie](https://twitter.com/the_real_stacie) on Twitter
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -39,7 +39,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 You can report violations in the following ways:
 
-- Email [Stacie Taylor-Cima](mailto:code-of-conduct@the-collab-lab.codes)
+- Email Stacie Taylor-Cima at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
 - Direct message @stacie in the Collab Lab Slack workspace
 - Private message [@the_real_stacie](https://twitter.com/the_real_stacie) on Twitter
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -46,7 +46,7 @@
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
             <p>You can report violations in the following ways:</p>
             <ul>
-                <li>Email <a href="mailto:code-of-conduct@the-collab-lab.codes">Stacie Taylor-Cima</a></li>
+                <li>Email Stacie Taylor-Cima at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
                 <li>Direct message @stacie in the Collab Lab Slack workspace</li>
                 <li>Private message <a href="https://twitter.com/the_real_stacie">@the_real_stacie</a> on Twitter</li>
             </ul>

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -46,7 +46,7 @@
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
             <p>You can report violations in the following ways:</p>
             <ul>
-                <li>Email <a href="mailto:stacietaylorcima@gmail.com">Stacie Taylor-Cima</a></li>
+                <li>Email <a href="mailto:code-of-conduct@the-collab-lab.codes">Stacie Taylor-Cima</a></li>
                 <li>Direct message @stacie in the Collab Lab Slack workspace</li>
                 <li>Private message <a href="https://twitter.com/the_real_stacie">@the_real_stacie</a> on Twitter</li>
             </ul>


### PR DESCRIPTION
## Description

Update the Code of Contact email address listed on the Collab Lab website to reflect the new the-collab-lab.codes address. 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | ✨ Update content |

## Testing Steps / QA Criteria

* Visit the Code of Conduct page of the website
* Make sure that when you click on the email link you're directed to an email with code-of-conduct@the-collab-lab.codes as the recipient. 