### PR TITLE
Change Google font to an @import

### DIFF
--- a/build/about-us/index.html
+++ b/build/about-us/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <meta content="width=device-width, initial-scale=1" name="viewport">
         <title>The Collaborators / About Us</title>
-        <link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext" rel="stylesheet">
         <link href="/assets/styles.css" rel="stylesheet">
     </head>
     <body>

--- a/build/assets/styles.css
+++ b/build/assets/styles.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext');
 @import 'carousel.css';
 @import 'members.css';
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>Code of Conduct / The Collab Lab</title>
-        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext">
         <link rel="stylesheet" href="/assets/styles.css">
     </head>
     <body>

--- a/build/index.html
+++ b/build/index.html
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>The Collab Lab</title>
-        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext">
         <link rel="stylesheet" href="/assets/styles.css">
         <script defer src="/assets/behaviors.js"></script>
     </head>


### PR DESCRIPTION
Before:

We were linking to our Google font in the `<head>` of each of our pages, as follows:

    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext">

But ours is an audience with browsers newer than Internet Explorer *6,* so we are free to use the CSS `@import` declaration to import this in one place.

After:

Import our font stylesheet within our main `styles.css` so we can maintain it one place, as follows:

    @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,600&display=swap&subset=latin-ext');