### PR TITLE
Change 'interest form' to 'application'

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -68,15 +68,15 @@
                 </dl>
             </blockquote>
             <h3>Join us!</h3>
-            <p>We are currently accepting expressions of interest to participate in Collab Lab. Please fill out the interest form that best fits you.</p>
+            <p>We are currently accepting applications to participate in Collab Lab. Please fill out the application that best fits you.</p>
             <ul>
-                <li><a href="https://forms.gle/jKsCEqHBVxrLjDGe6">I’m interested in participating as a developer.</a></li>
-                <li><a href="https://forms.gle/UhcT8HvnEc7C3pDF8">I’m interested in helping out as a mentor.</a></li>
+                <li><a href="https://forms.gle/jKsCEqHBVxrLjDGe6">I’m applying to participate as a developer.</a></li>
+                <li><a href="https://forms.gle/UhcT8HvnEc7C3pDF8">I’m applying to participate as a mentor.</a></li>
             </ul>
             <p><a href="/about-us/#participants">Successful Collab Lab participants</a> come in having already learned basic web development and programming concepts. We don’t teach coding; we teach collaboration! You don’t need a ton of experience, but <strong>you should have completed the equivalent of a coding bootcamp</strong> where you’ve learned at a minimum basic HTML, CSS, and JavaScript.</p>
             <p><a href="/about-us/#mentors">Our mentors</a> are mostly professional web developers. Project or product management skills are helpful as well, though not strictly required. Mentors work in pairs to guide cohorts, so we will do our best to ensure complimentary skills among the mentors on the team.</p>
             <blockquote>
-                <p><strong>Note:</strong> Participants and mentors for <strong>the third cohort have been selected.</strong> Congratulations to them! If you’re interested in participating in the future, <a href="https://forms.gle/jKsCEqHBVxrLjDGe6">please fill out the interest form</a>. We expect the fourth cohort to kick off <strong>January of 2020.</strong></p>
+                <p><strong>Note:</strong> Participants and mentors for <strong>the third cohort have been selected.</strong> Congratulations to them! If you’re interested in participating in the future, <a href="https://forms.gle/jKsCEqHBVxrLjDGe6">please fill out an application</a>. We expect the fourth cohort to kick off <strong>January of 2020.</strong></p>
             </blockquote>
             <p>Follow <a href="https://twitter.com/_collab_lab">@_collab_lab</a> on Twitter to get in touch and keep up on the latest news about the program.</p>
             <p>Want to support The Collab Lab? Consider becoming a sponsor! Info on tiers for monthly giving is on <a href="https://github.com/sponsors/segdeha">our GitHub Sponsors page</a>. ❤️</p>


### PR DESCRIPTION
## Description

Changing our language from "interest form" to "application" will help convey that this form is an application and will be the final chance for applicants to show off their skills.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :hammer: Content update       |

## Related Issue

More details in [this Slack thread here](https://the-collab-lab.slack.com/archives/GLQ89ULE6/p1578283788033400). 

## Before / After

**Before:** We used the term "interest form" in all our copy when referring to the Google Form that folks fill out to be considered for future cohorts.  

**After:** We use the term "application" to refer to the Google Form folks need to fill out to be considered for a spot in a future cohort. 

## Testing Steps / QA Criteria

- [ ] Double-check to make sure everything sounds okay and that there are no "interest forms" that were missed in this sweep. 