### PR TITLE
Add Lisa as PoC on CoC

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -39,9 +39,8 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 You can report violations in the following ways:
 
-- Email Stacie Taylor-Cima at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie in the Collab Lab Slack workspace
-- Private message [@the_real_stacie](https://twitter.com/the_real_stacie) on Twitter
+- Email Stacie Taylor-Cima and Lisa Smith at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
+- Direct message `@stacie` and/or `@Lisa Smith` in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -52,9 +52,8 @@
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
             <p>You can report violations in the following ways:</p>
             <ul>
-                <li>Email Stacie Taylor-Cima at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie in the Collab Lab Slack workspace</li>
-                <li>Private message <a href="https://twitter.com/the_real_stacie">@the_real_stacie</a> on Twitter</li>
+                <li>Email Stacie Taylor-Cima and Lisa Smith at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
+                <li>Direct message @stacie and/or @Lisa Smith in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>


### PR DESCRIPTION
## Description

I've added that folks can reach Lisa at our `code-of-conduct@the-collab-lab.codes` email address and on Slack. 

I've also removed the ability to DM me on Twitter. Originally I had that there so folks who weren't in Slack had a channel to reach me, but now that we have the email address, that requirement is satisfied.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :sparkles: New feature     |

## Related Issue

[This issue on Administrivia](https://github.com/orgs/the-collab-lab/projects/3#card-32300382)

## Before / After

* Before: CoC only listed Stacie as a contact. 
* After: CoC lists Stacie and Lisa as contacts. 
