### PR TITLE
Add Michelle as PoC for CoC

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -39,8 +39,8 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 You can report violations in the following ways:
 
-- Email Stacie Taylor-Cima and Lisa Smith at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message `@stacie` and/or `@Lisa Smith` in the Collab Lab Slack workspace
+- Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
+- Direct message @stacie, @Lisa Smith and/or @Michelle Sauque in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -40,7 +40,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 You can report violations in the following ways:
 
 - Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie, @Lisa Smith and/or @Michelle Sauque in the Collab Lab Slack workspace
+- Direct message @stacie, @lisa and/or @Michelle Sauque in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -53,7 +53,7 @@
             <p>You can report violations in the following ways:</p>
             <ul>
                 <li>Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie, @Lisa Smith and/or @Michelle Sauque in the Collab Lab Slack workspace</li>
+                <li>Direct message @stacie, @lisa and/or @Michelle Sauque in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -52,8 +52,8 @@
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
             <p>You can report violations in the following ways:</p>
             <ul>
-                <li>Email Stacie Taylor-Cima and Lisa Smith at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie and/or @Lisa Smith in the Collab Lab Slack workspace</li>
+                <li>Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
+                <li>Direct message @stacie, @Lisa Smith and/or @Michelle Sauque in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>


### PR DESCRIPTION
## Description

Michelle Sauque has agreed to join the Code of Conduct team, so I've added her to the Code of Contact details in our repo and on our website.

_TODO: Ideally we'd all have Slack handles without spaces in the name. There is absolutely no harm in keeping them as-is, but it does look a bit strange on the website._

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :sparkles: New feature     |

## Related Issue

https://github.com/orgs/the-collab-lab/projects/3#card-32564217

## Before / After

- Before: Only Stacie and Lisa were listed as points of contact for the Code of Conduct. 
- After: Stacie, Lisa, and Michelle are listed as points of contact for the Code of Conduct. 

![updated CoC with Michelle](https://zappy.zapier.com/4167d731fe8159d32e0ae439b5bc19cd.png)
