### PR TITLE
Change Michelle's Slack handle to first name

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -40,7 +40,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 You can report violations in the following ways:
 
 - Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie, @lisa and/or @Michelle Sauque in the Collab Lab Slack workspace
+- Direct message @stacie, @lisa and/or @michelle in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -53,7 +53,7 @@
             <p>You can report violations in the following ways:</p>
             <ul>
                 <li>Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie, @lisa and/or @Michelle Sauque in the Collab Lab Slack workspace</li>
+                <li>Direct message @stacie, @lisa and/or @michelle in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>


### PR DESCRIPTION
## Description

I had the points of contact for the Code of Conduct update their Slack handles to just their first name for purely aesthetic reasons. But, this PR updates Michelle's Slack handle on the CoC pages and I think it looks much cleaner! :sparkles:

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓ | :sparkles: Content Update     |

## Related Issue

https://github.com/orgs/the-collab-lab/projects/3#card-32564217

## Before / After

- Before: Michelle's Slack handle had a white space between her first and last name. 
- After: Slack hand

les are all a single name. 

![](https://zappy.zapier.com/8d8817810669cc525d5697cc00374d88.png)
