### PR TITLE
Update language on home and about to reflect Stacie's new title

### DIFF
--- a/build/about-us/index.html
+++ b/build/about-us/index.html
@@ -260,7 +260,7 @@
                     </div>
                 </li>
                 <li class="member-container span-3">
-                    <p><strong>Stacie Taylor-Cima</strong> is Collab Lab’s point of contact for <a href="/code-of-conduct/">Code of Conduct</a> concerns. By day, she’s a Customer Champion at <a href="https://zapier.com">Zapier</a> and participated as a developer in Collab Lab’s first ever cohort.</p>
+                    <p><strong>Stacie Taylor-Cima</strong> is Collab Lab’s point of contact for <a href="/code-of-conduct/">Code of Conduct</a> concerns. By day, she’s a Frontend Engineer at <a href="https://zapier.com">Zapier</a> and participated as a developer in Collab Lab’s first ever cohort.</p>
                     <p><a href="https://www.stacietaylorcima.com/">Stacie</a> lives in Sacramento, California, with her husband and 2 young kids.</p>
                 </li>
                 <li class="member-container">

--- a/build/index.html
+++ b/build/index.html
@@ -74,7 +74,7 @@
                 <li><a href="https://forms.gle/UhcT8HvnEc7C3pDF8">I’m applying to participate as a mentor.</a></li>
             </ul>
             <p><a href="/about-us/#participants">Successful Collab Lab participants</a> come in having already learned basic web development and programming concepts. We don’t teach coding; we teach collaboration! You don’t need a ton of experience, but <strong>you should have completed the equivalent of a coding bootcamp</strong> where you’ve learned at a minimum basic HTML, CSS, and JavaScript.</p>
-            <p><a href="/about-us/#mentors">Our mentors</a> are mostly professional web developers. Project or product management skills are helpful as well, though not strictly required. Mentors work in pairs to guide cohorts, so we will do our best to ensure complimentary skills among the mentors on the team.</p>
+            <p><a href="/about-us/#mentors">Our mentors</a> are professional web developers. Project or product management skills are helpful as well, though not strictly required. Mentors work in pairs to guide cohorts, so we will do our best to ensure complimentary skills among the mentors on the team.</p>
             <blockquote>
                 <p><strong>Note:</strong> Participants and mentors for <strong>the fifth cohort have been selected.</strong> <em>Congratulations to them!</em> If you’re interested in participating in the future, <a href="https://forms.gle/jKsCEqHBVxrLjDGe6">please fill out an application</a>. We expect the sixth cohort to kick off <strong>April of 2020.</strong></p>
             </blockquote>


### PR DESCRIPTION
## Description

Stacie is a frontend engineer at Zapier now, so we've updated the language on home and about up pages to indicate that all of our mentors are engineers by day. 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   | :bug: Bug fix              |
|  ✓   | :sparkles: Copy update     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Related Issue

Closes #31 
