### PR TITLE
Add Adrienne to CoC

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -39,8 +39,8 @@ We will respect confidentiality requests for the purpose of protecting victims o
 
 You can report violations in the following ways:
 
-- Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie, @lisa and/or @michelle in the Collab Lab Slack workspace
+- Email Stacie Taylor-Cima, Lisa Smith, Michelle Sauque, and Adrienne Lowe at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
+- Direct message @stacie, @lisa, @michelle and/or @adriennee in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -40,7 +40,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 You can report violations in the following ways:
 
 - Email Stacie Taylor-Cima, Lisa Smith, Michelle Sauque, and Adrienne Lowe at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie, @lisa, @michelle and/or @adrienne in the Collab Lab Slack workspace
+- Direct message @stacie, @lisa, @michelle, and/or @adrienne in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -40,7 +40,7 @@ We will respect confidentiality requests for the purpose of protecting victims o
 You can report violations in the following ways:
 
 - Email Stacie Taylor-Cima, Lisa Smith, Michelle Sauque, and Adrienne Lowe at [code-of-conduct@the-collab-lab.codes](mailto:code-of-conduct@the-collab-lab.codes)
-- Direct message @stacie, @lisa, @michelle and/or @adriennee in the Collab Lab Slack workspace
+- Direct message @stacie, @lisa, @michelle and/or @adrienne in the Collab Lab Slack workspace
 
 ## Consequences
 

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -52,8 +52,8 @@
             <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Collab Lab members or the general public. We will not name harassment victims without their affirmative consent.</p>
             <p>You can report violations in the following ways:</p>
             <ul>
-                <li>Email Stacie Taylor-Cima, Lisa Smith, and Michelle Sauque at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie, @lisa and/or @michelle in the Collab Lab Slack workspace</li>
+                <li>Email Stacie Taylor-Cima, Lisa Smith, Michelle Sauque, and Adrienne Lowe at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
+                <li>Direct message @stacie, @lisa, @michelle and/or @adrienne in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>

--- a/build/code-of-conduct/index.html
+++ b/build/code-of-conduct/index.html
@@ -53,7 +53,7 @@
             <p>You can report violations in the following ways:</p>
             <ul>
                 <li>Email Stacie Taylor-Cima, Lisa Smith, Michelle Sauque, and Adrienne Lowe at <a href="mailto:code-of-conduct@the-collab-lab.codes">code-of-conduct@the-collab-lab.codes</a></li>
-                <li>Direct message @stacie, @lisa, @michelle and/or @adrienne in the Collab Lab Slack workspace</li>
+                <li>Direct message @stacie, @lisa, @michelle, and/or @adrienne in the Collab Lab Slack workspace</li>
             </ul>
             <h2>Consequences</h2>
             <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>


### PR DESCRIPTION
Add Adrienne to our Code of Conduct website materials. 

_Note: Adrienne will be updating her Slack handle and if it is something other than `@adrienne` we will need to revisit this_