### PR TITLE
added Matthew to the Mentors section of the About Us page

### DIFF
--- a/build/about-us/index.html
+++ b/build/about-us/index.html
@@ -496,14 +496,14 @@
                     <img alt="Matthew Hughes" class="team-member-photo" src="/assets/img/members/matthewhughes.jpg">
                     <div class="member-caption">
                         <p>Matthew</p>
-                        <a class="social-media-logo" href="https://github.com/mjhughes707" target="blank"><img src="/assets/img/icons/github.png" alt="GitHub"></a>
-                        <a class="social-media-logo" href="https://www.linkedin.com/in/mjhughes707" target="blank"><img src="/assets/img/icons/linkedin.png" alt="LinkedIn"></a>
-                        <a class="social-media-logo" href="https://twitter.com/mjhughes707" target="blank"><img src="/assets/img/icons/twitter.png" alt="Twitter"></a>
+                        <a class="social-media-logo" href="https://github.com/mjhughes707"><img src="/assets/img/icons/github.png" alt="GitHub"></a>
+                        <a class="social-media-logo" href="https://www.linkedin.com/in/mjhughes707"><img src="/assets/img/icons/linkedin.png" alt="LinkedIn"></a>
+                        <a class="social-media-logo" href="https://twitter.com/mjhughes707"><img src="/assets/img/icons/twitter.png" alt="Twitter"></a>
                     </div>
                 </li>
                 <li class="member-container span-3">
-                    <p><strong>Matthew Hughes</strong> is a Contracted Software Engineer, most recently at <a href="https://gridrival.com/" target="_blank">GridRival</a>, as well as a volunteer Social Media & Marketing Coordinator with the <a href="https://www.meetup.com/Portland-JR-DEVELOPER-Meetup/" target="_blank">Portland Jr Dev</a> group.</p>
-                    <p>A world traveler, dual citizen and overall nomad by nature, <a href="https://matthewjhughes.com/" target="_blank">Matthew</a> currently resides in Windsor, California with his fiancée, RaeLynn.</p>
+                    <p><strong>Matthew Hughes</strong> is a Contracted Software Engineer, most recently at <a href="https://gridrival.com/">GridRival</a>, as well as a volunteer Social Media & Marketing Coordinator with the <a href="https://www.meetup.com/Portland-JR-DEVELOPER-Meetup/">Portland Jr Dev</a> group.</p>
+                    <p>A world traveler, dual citizen and overall nomad by nature, <a href="https://matthewjhughes.com/">Matthew</a> currently resides in Windsor, California with his fiancée, RaeLynn.</p>
                 </li>
                 </li>
                 <li class="member-container">

--- a/build/about-us/index.html
+++ b/build/about-us/index.html
@@ -493,6 +493,20 @@
                     <p>Lisa is a founding director of the Raleigh-Durham, NC chapter of <a href="https://www.womenwhocode.com/">Women Who Code</a>. She lives and works remotely in Chapel Hill, NC with her two daughters.</p>
                 </li>
                 <li class="member-container">
+                    <img alt="Matthew Hughes" class="team-member-photo" src="/assets/img/members/matthewhughes.jpg">
+                    <div class="member-caption">
+                        <p>Matthew</p>
+                        <a class="social-media-logo" href="https://github.com/mjhughes707" target="blank"><img src="/assets/img/icons/github.png" alt="GitHub"></a>
+                        <a class="social-media-logo" href="https://www.linkedin.com/in/mjhughes707" target="blank"><img src="/assets/img/icons/linkedin.png" alt="LinkedIn"></a>
+                        <a class="social-media-logo" href="https://twitter.com/mjhughes707" target="blank"><img src="/assets/img/icons/twitter.png" alt="Twitter"></a>
+                    </div>
+                </li>
+                <li class="member-container span-3">
+                    <p><strong>Matthew Hughes</strong> is a Contracted Software Engineer, most recently at <a href="https://gridrival.com/" target="_blank">GridRival</a>, as well as a volunteer Social Media & Marketing Coordinator with the <a href="https://www.meetup.com/Portland-JR-DEVELOPER-Meetup/" target="_blank">Portland Jr Dev</a> group.</p>
+                    <p>A world traveler, dual citizen and overall nomad by nature, <a href="https://matthewjhughes.com/" target="_blank">Matthew</a> currently resides in Windsor, California with his fiancée, RaeLynn.</p>
+                </li>
+                </li>
+                <li class="member-container">
                     <img alt="Michael Sholty" class="team-member-photo" src="/assets/img/members/michaelsholty.jpg">
                     <div class="member-caption">
                         <p>Michael</p>


### PR DESCRIPTION
## Description

The purpose of this issue was to add myself to the About Us page on the website under the Mentors section. As my photo was already included as part of a previous cohort, no additional files were necessary to add.

## Related Issue

Closes #66 

## Acceptance Criteria

- [x] Mentors are ordered in alphabetical order by first name
- [x] Your photo should be in JPG format, be 400x400px, and saved at around 30% quality
- [x] Your photo should be named firstnamelastname.jpg and put in /build/assets/img/members/