### PR TITLE
Remove "Learn more about applying" callout

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -81,9 +81,6 @@
             <h3>Join us!</h3>
             <p><a href="/about-us/#participants">Successful Collab Lab participants</a> come in having already learned basic web development and programming concepts. We don’t teach coding; we teach collaboration! You don’t need a ton of experience, but <strong>you should have completed the equivalent of a coding bootcamp</strong> where you’ve learned (at a minimum) basic HTML, CSS, and JavaScript and have completed a project or two in <a href="https://reactjs.org/">React</a>.</p>
             <blockquote>
-                <p><a href="/apply/">Learn more about applying to <strong>participate in a Collab Lab cohort.</strong></a></p>
-            </blockquote>
-            <blockquote>
                 <p><a href="/apply/">Applications are open</a> for our October 2020 cohort that will kick off on <strong>October 4, 2020.</strong>
                     This cohort will be comprised of teams in North America, Latin America (Spanish speakers only), and Europe/Africa.
                     We will accept applications until <strong>September 12</strong> and applicants will be notified of their status the following week.</p>


### PR DESCRIPTION
This PR removes the  "Learn more about applying" callout on the homepage in favor of the "Applications are open" callout. Both of those callouts link to the `/apply` page. 