### PR TITLE
Add GitHub Sponsors button and update other language

### DIFF
--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -6,13 +6,22 @@ navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <
 ---
 
 <h2 id="mission">Our Mission</h2>
+<figure class="float-right">
+  <img
+    src="/assets/img/weekly-call.jpg"
+    alt="Collab Lab mentors and participants taking part in one of our weekly check-in calls"
+  />
+  <figcaption>
+    Cohort 2 and mentors taking part in a weekly check-in call
+  </figcaption>
+</figure>
 <p>
   The Collab Lab exists to help early-career developers gain their footholds in
   tech by providing real-world experience working on software teams.
 </p>
 <h2 id="origin-story">Our Origin Story</h2>
 <p>
-  In June of 2019, <a href="#founder">Andrew Hedges</a> grabbed a quick beer
+  In June of 2019, <a href="/who-we-are/#founder">Andrew Hedges</a> grabbed a quick beer
   before
   <a
     href="https://www.meetup.com/Portland-JR-DEVELOPER-Meetup/events/256869529/"
@@ -30,14 +39,12 @@ navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <
 </p>
 <p>
   <strong>Collab Lab kicked off our first cohort that August</strong> with
-  Scott, Caitlyn, Stacie Taylor-Cima, and Kate Sowles participating as
+  Scott, Caitlyn, Stacie Taylor, and Kate Sowles participating as
   developers with Andrew mentoring the group through the 8-week project.
 </p>
 <p>
   Since we launched, the response to Collab Lab has been overwhelmingly
-  positive, further confirming the need for what we’re doing. We’ve collected a
-  long backlog of early career developers who have expressed interest in
-  participating and are working hard to scale up the program to accommodate
+  positive, further confirming the need for what we’re doing. As of November, 2020, we’ve worked with 60 early-career developers in 6 countries and are working hard to scale up the program to accommodate
   demand.
 </p>
 <blockquote>
@@ -54,15 +61,6 @@ navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <
   >
 </blockquote>
 <h2 id="support">Support Collab Lab!</h2>
-<figure class="float-right">
-  <img
-    src="/assets/img/weekly-call.jpg"
-    alt="Collab Lab mentors and participants taking part in one of our weekly check-in calls"
-  />
-  <figcaption>
-    Cohort 2 and mentors taking part in a weekly check-in call
-  </figcaption>
-</figure>
 <p>
   The Collab Lab is
   <strong>volunteer-driven and free for participants.</strong> We intentionally
@@ -77,9 +75,10 @@ navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <
   as much as possible. We would love to have the ability to use upgraded
   versions of some of these tools to provide a better experience for our
   volunteers and participants. To this end, we accept
-  <a href="https://github.com/sponsors/segdeha">sponsorships through GitHub</a>.
+  <a href="https://github.com/sponsors/the-collab-lab">sponsorships through GitHub</a>.
   ❤️
 </p>
+<iframe src="https://github.com/sponsors/the-collab-lab/button" title="Sponsor the-collab-lab" height="35" width="116" style="border: 0;"></iframe>
 <h2>Get in touch!</h2>
 <p>
   The Collab Lab is on Twitter

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -17,7 +17,7 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-ar
 </figure>
 <p>
   The Collab Lab exists to help early-career developers gain their footholds in
-  tech. Our participants are all early career developers, many of them veterans
+  tech. Our participants are all early-career developers, many of them veterans
   of coding bootcamps or self-study, some of them a year or two into their tech
   careers.
 </p>

--- a/pages/index.html
+++ b/pages/index.html
@@ -3,7 +3,7 @@ layout: mlayout.hbs
 htmlTitle: The Collab Lab
 pageTitle: The Collab Lab
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
-pageSubTitle: <h2>Gain <strong>practical experience</strong> by working remotely on<strong> real world projects</strong> with other<strong> early career developers.</strong></h2>
+pageSubTitle: <h2>Gain <strong>practical experience</strong> by working remotely on<strong> real world projects</strong> with other<strong> early-career developers.</strong></h2>
 ---
 
 <figure class="carousel">

--- a/pages/who-we-are.html
+++ b/pages/who-we-are.html
@@ -16,7 +16,7 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li
   <a href="https://hbr.org/2016/01/what-having-a-growth-mindset-actually-means"
     >growth mindset</a
   >, opening yourself to learning, and taking risks in a relatively low-stakes
-  setting. Seasoned technologists guide these early career developers as they
+  setting. Seasoned technologists guide these early-career developers as they
   pair program, review each others’ code, and submit & merge pull requests. They
   are also coached on how to be effective on a fully distributed (remote) team
   by


### PR DESCRIPTION
<img width="834" alt="image" src="https://user-images.githubusercontent.com/4306/99928748-550b0400-2cff-11eb-9229-c28a0d33f589.png">

The impetus for this PR was to add a GitHub Sponsors button to the About Us page, but once I was in there, I noticed other language that needed updating including:

- Changing Stacie’s last name from Taylor-Cima to Taylor
- Changing language related to our selection process
- Changing “early career” to the more grammatically correct “early-career” across the site

I also moved the image up the page to make it more visually interesting.