### PR TITLE
Add a Tech Talks page to the website

### DIFF
--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -168,6 +168,26 @@ figure.float-right figcaption {
   font-style: italic;
 }
 
+.tech-talks {
+  list-style: none;
+  margin: 1em 0;
+  padding: 0;
+}
+  .tech-talks > li {
+    border-bottom: solid 1px #ccc;
+    margin: 1rem 0;
+    padding-bottom: 1rem;
+  }
+    .tech-talks > li:first-child {
+      border-top: solid 1px #ccc;
+    }
+  .tech-talks h3 {
+    margin: 1.5rem 0;
+  }
+    .tech-talks h3 em {
+      font-weight: normal;
+    }
+
 /* small screens */
 /* under 820px wide, adjust margins, fix the footer and tweak how we display the carousel */
 @media screen and (max-width: 819px) {

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -1,7 +1,7 @@
 const { request } = require('graphql-request');
 const format = require('date-fns/format');
 const parseISO = require('date-fns/parseISO');
-const { TeamsQuery, MentorsQuery, AdvisorsQuery, FoundersQuery, PagesQuery } = require('./queries');
+const { TeamsQuery, MentorsQuery, AdvisorsQuery, FoundersQuery, PagesQuery, TechTalksQuery } = require('./queries');
 
 /**
  * Transforms two dates of type 2020-10-10 and 2020-11-11 to
@@ -86,8 +86,19 @@ const getPages = async () => {
   }
 };
 
+const getTechTalks = async () => {
+  try {
+    const { techTalks } = await request(graphQLEndpoint, TechTalksQuery);
+    return techTalks;
+  }
+  catch (e) {
+    throw new Error('There was a problem getting Tech Talks', e);
+  }
+};
+
 exports.getTeams = getTeams;
 exports.getMentors = getMentors;
 exports.getAdvisors = getAdvisors;
 exports.getFounders = getFounders;
 exports.getPages = getPages;
+exports.getTechTalks = getTechTalks;

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -89,7 +89,21 @@ const getPages = async () => {
 const getTechTalks = async () => {
   try {
     const { techTalks } = await request(graphQLEndpoint, TechTalksQuery);
-    return techTalks;
+    const result = techTalks.map(talk => {
+      talk.formattedDate = format(parseISO(talk.dateAndTime), 'd MMM y');
+      talk.youTubeEmbedUrl = null;
+      if (talk.youTubeUrl) {
+        // source = https://www.youtube.com/watch?v=3mci0a8AWnI
+        // target = https://www.youtube.com/embed/3mci0a8AWnI
+        const matches = talk.youTubeUrl.match(/v=(\w+)/);
+        if (matches.length > 1) {
+          const id = matches[1];
+          talk.youTubeEmbedUrl = `https://www.youtube.com/embed/${id}`;
+        }
+      }
+      return talk;
+    });
+    return result;
   }
   catch (e) {
     throw new Error('There was a problem getting Tech Talks', e);

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -100,8 +100,32 @@ const PagesQuery = gql`
   }
 `;
 
+const TechTalksQuery = gql`
+  query GetTechTalks {
+    techTalks(orderBy: dateAndTime_DESC) {
+      title
+      presenters {
+        fullName
+      }
+      dateAndTime
+      description {
+        html
+      }
+      meetupUrl
+      youTubeUrl
+      image {
+        url
+        width
+        height
+      }
+      visible
+    }
+  }
+`;
+
 exports.TeamsQuery = TeamsQuery;
 exports.MentorsQuery = MentorsQuery;
 exports.AdvisorsQuery = AdvisorsQuery;
 exports.FoundersQuery = FoundersQuery;
 exports.PagesQuery = PagesQuery;
+exports.TechTalksQuery = TechTalksQuery;

--- a/pages/tech-talks.11tydata.js
+++ b/pages/tech-talks.11tydata.js
@@ -1,0 +1,9 @@
+const { getTechTalks } = require('./graphql/data');
+
+module.exports = async () => {
+  const techTalks = await getTechTalks();
+
+  return {
+    techTalks,
+  };
+};

--- a/pages/tech-talks.html
+++ b/pages/tech-talks.html
@@ -1,0 +1,25 @@
+---
+layout: mlayout.hbs
+htmlTitle: Who We Are | The Collab Lab
+pageTitle: <a href="/">The Collab Lab</a> / Who We Are
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+---
+
+<h2>Tech Talks by The Collab Lab</h2>
+<p>
+  Join us for a new Tech Talk every 2 weeks. RSVP on <a href="https://www.meetup.com/tech-talks-by-the-collab-lab">Meetup</a>.
+</p>
+
+<!-- <iframe width="560" height="315" src="https://www.youtube.com/embed/3mci0a8AWnI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
+
+<ul>
+{%- for techTalk in techTalks -%}
+  <li>{{techTalk}}</li>
+{%- endfor -%}
+</ul>
+
+<h2>Have a talk idea? Get in touch!</h2>
+<p>
+  Interested in speaking at our Meetup? Email us at 
+  <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#116;&#101;&#99;&#104;&#45;&#116;&#97;&#108;&#107;&#115;&#64;&#116;&#104;&#101;&#45;&#99;&#111;&#108;&#108;&#97;&#98;&#45;&#108;&#97;&#98;&#46;&#99;&#111;&#100;&#101;&#115;">&#116;&#101;&#99;&#104;&#45;&#116;&#97;&#108;&#107;&#115;&#64;&#116;&#104;&#101;&#45;&#99;&#111;&#108;&#108;&#97;&#98;&#45;&#108;&#97;&#98;&#46;&#99;&#111;&#100;&#101;&#115;</a>.
+</p>

--- a/pages/tech-talks.html
+++ b/pages/tech-talks.html
@@ -1,8 +1,8 @@
 ---
 layout: mlayout.hbs
-htmlTitle: Who We Are | The Collab Lab
-pageTitle: <a href="/">The Collab Lab</a> / Who We Are
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+htmlTitle: Tech Talks | The Collab Lab
+pageTitle: <a href="/">The Collab Lab</a> / Tech Talks
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li>Tech Talks</li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 ---
 
 <h2>Tech Talks by The Collab Lab</h2>
@@ -10,11 +10,18 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li
   Join us for a new Tech Talk every 2 weeks. RSVP on <a href="https://www.meetup.com/tech-talks-by-the-collab-lab">Meetup</a>.
 </p>
 
-<!-- <iframe width="560" height="315" src="https://www.youtube.com/embed/3mci0a8AWnI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
-
-<ul>
+<ul class="tech-talks">
 {%- for techTalk in techTalks -%}
-  <li>{{techTalk}}</li>
+  {% if techTalk.visible %}
+  <li>
+    <h3>{{techTalk.title}} – <em>{{(techTalk.formattedDate}}</em></h3>
+    {% if techTalk.youTubeEmbedUrl %}
+      <iframe width="560" height="315" src="{{techTalk.youTubeEmbedUrl}}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    {% endif %}
+    {{techTalk.description.html}}
+    <p><a href="{{techTalk.meetupUrl}}">Meetup page for {{techTalk.title}}</a></p>
+  </li>
+  {% endif %}
 {%- endfor -%}
 </ul>
 


### PR DESCRIPTION
This PR creates a new page on the website, driven by GraphCMS. The page is super basic for now, but at least it gets the information up on our website.

<img width="915" alt="image" src="https://user-images.githubusercontent.com/4306/101587005-082e5b00-3998-11eb-9a6c-03014acecf65.png">
