### PR TITLE
Preconnect to domains to increase performance

### DIFF
--- a/pages/_includes/mlayout.hbs
+++ b/pages/_includes/mlayout.hbs
@@ -2,11 +2,15 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Gain practical experience by working remotely on real world projects with other early-career developers.">
     <title>{{ htmlTitle }}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com/">
+    <link rel="preconnect" href="https://fonts.googleapis.com/" crossorigin>
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com/">
+    <meta name="description" content="Gain practical experience by working remotely on real world projects with other early-career developers.">
     <link href="/assets/styles.css" rel="stylesheet">
-    <script defer src="/assets/behaviors.js"></script>
+    <script async defer src="/assets/behaviors.js"></script>
     <script type="application/ld+json">
     {
       "@context": "http://www.schema.org",

--- a/pages/_includes/mlayout.hbs
+++ b/pages/_includes/mlayout.hbs
@@ -10,7 +10,7 @@
     <link rel="dns-prefetch" href="https://fonts.googleapis.com/">
     <meta name="description" content="Gain practical experience by working remotely on real world projects with other early-career developers.">
     <link href="/assets/styles.css" rel="stylesheet">
-    <script async defer src="/assets/behaviors.js"></script>
+    <script defer src="/assets/behaviors.js"></script>
     <script type="application/ld+json">
     {
       "@context": "http://www.schema.org",


### PR DESCRIPTION
This PR adds `<link rel="preconnect">` and (as a fallback for older browsers) `<link rel="dns-prefetch">` tags to the document `<head>` to warm up those connections earlier in the render lifecycle.

It also changes the order of a couple of the elements in the `<head>` (which is, honestly, a total micro-optimization).

## Lighthouse before:

![image](https://user-images.githubusercontent.com/4306/101678155-68fa7980-3a12-11eb-9bd2-22a5e8ad52fc.png)

## Lighthouse after:

![image](https://user-images.githubusercontent.com/4306/101678247-83345780-3a12-11eb-98ad-fefa8b171bbf.png)

## Webpagetest.org results

The following shows results for the live site and preview deploy for the waterfall of requests + processing. The fact that everything shifts to the left on the preview deploy is good.

![e48c9f9fa0ceedd3b5e468840e12679b](https://user-images.githubusercontent.com/4306/101680431-8e3cb700-3a15-11eb-9871-a4eb990cd80b.gif)
