### PR TITLE
Add native lazy loading to images

### DIFF
--- a/pages/who-we-are.html
+++ b/pages/who-we-are.html
@@ -37,6 +37,7 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li
   {%- for developer in team.developers -%}
   <li class="member-container">
     <img
+      loading="lazy"
       alt="{{developer.fullName}}"
       class="team-member-photo"
       src="{{developer.pathToPhoto}}"
@@ -73,6 +74,7 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li
   {%- for mentor in mentors -%}
   <li class="member-container">
     <img
+      loading="lazy"
       alt="{{mentor.fullName}}"
       class="team-member-photo"
       src="{{mentor.pathToPhoto}}"
@@ -114,6 +116,7 @@ navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li
   {%- for founder in founders -%}
   <li class="member-container">
     <img
+      loading="lazy"
       alt="{{founder.fullName}}"
       class="team-member-photo"
       src="{{founder.pathToPhoto}}"


### PR DESCRIPTION
This PR adds native lazy loading to images on the Who We Are page.

This has been in Chrome for a while and I just saw that it landed in WebKit 4 days ago, so should be coming to Safari soon!