### PR TITLE
Fix missing social links

### DIFF
--- a/pages/who-we-are.html
+++ b/pages/who-we-are.html
@@ -45,7 +45,7 @@ teams -%}
     <div class="member-caption">
       <p>{{developer.firstName}}</p>
       {% for social in socials %} {% assign urlProp = social | append: 'Url' %}
-      {% if developer[urlProp].length %} {% assign platformName = social |
+      {% if developer[urlProp].length > 0 %} {% assign platformName = social |
       capitalize %}
       <a
         class="social-media-logo"
@@ -80,7 +80,7 @@ teams -%}
     <div class="member-caption">
       <p>{{mentor.firstName}}</p>
       {% for social in socials %} {% assign urlProp = social | append: 'Url' %}
-      {% if mentor[urlProp].length %} {% assign platformName = social |
+      {% if mentor[urlProp].length > 0 %} {% assign platformName = social |
       capitalize %}
       <a
         class="social-media-logo"
@@ -116,7 +116,7 @@ teams -%}
     <div class="member-caption">
       <p>{{founder.firstName}}</p>
       {% for social in socials %} {% assign urlProp = social | append: 'Url' %}
-      {% if founder[urlProp].length %} {% assign platformName = social |
+      {% if founder[urlProp].length > 0 %} {% assign platformName = social |
       capitalize %}
       <a
         class="social-media-logo"


### PR DESCRIPTION
Before: In some cases social icons would show up on cards when the person didn’t have an URL set in GraphCMS

After: Icons only show up when the URL is set.

First noticed on Mariangel’s card:
<img width="215" alt="image" src="https://user-images.githubusercontent.com/4306/104479969-dbfa9100-5578-11eb-941b-306f9473ef10.png">
