### PR TITLE
Add Tech Talks to top nav

### DIFF
--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: About Us | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / About
-navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+navigation: <ul> <li>About</li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 ---
 
 <h2 id="mission">Our Mission</h2>

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: Apply | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Apply
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li>Apply</li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li>Apply</li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 ---
 
 {{html}}

--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: Code of Conduct | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Code of Conduct
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li>Code of Conduct</li> </ul>
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li>Code of Conduct</li> </ul>
 ---
 
 <h2>Code of Conduct</h2>

--- a/pages/index.html
+++ b/pages/index.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: The Collab Lab
 pageTitle: The Collab Lab
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 pageSubTitle: <h2>Gain <strong>practical experience</strong> by working remotely on<strong> real world projects</strong> with other<strong> early-career developers.</strong></h2>
 ---
 

--- a/pages/mentor.html
+++ b/pages/mentor.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: Mentor | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Mentor
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li>Mentor</li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/who-we-are/">Who We Are</a></li> <li><a href="/apply/">Apply</a></li> <li>Mentor</li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 ---
 
 {{html}}

--- a/pages/who-we-are.html
+++ b/pages/who-we-are.html
@@ -2,7 +2,7 @@
 layout: mlayout.hbs
 htmlTitle: Who We Are | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Who We Are
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Who We Are</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 ---
 
 <h2 id="participants">Participants</h2>


### PR DESCRIPTION
This change adds "Tech Talks" as a top-level nav item.

## Before

<img width="829" alt="image" src="https://user-images.githubusercontent.com/4306/104543236-f44ec800-55d9-11eb-8633-5cee1e2548d6.png">

## After

<img width="828" alt="image" src="https://user-images.githubusercontent.com/4306/104543263-fdd83000-55d9-11eb-84cb-dd76bbcdcf62.png">
