### PR TITLE
Update mentors to only display visible mentors

### DIFF
--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -83,7 +83,7 @@ const getTeams = async () => {
 const getMentors = async () => {
   try {
     const { collabies } = await request(graphQLEndpoint, MentorsQuery);
-    return collabies;
+    return collabies.filter(mentor => mentor.visible);
   } catch (e) {
     throw new Error('There was a problem getting Mentors', e);
   }

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -83,7 +83,7 @@ const getTeams = async () => {
 const getMentors = async () => {
   try {
     const { collabies } = await request(graphQLEndpoint, MentorsQuery);
-    return collabies.filter(mentor => mentor.visible);
+    return collabies;
   } catch (e) {
     throw new Error('There was a problem getting Mentors', e);
   }

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -28,7 +28,8 @@ const MentorsQuery = gql`
     collabies(
       where: {
         roles_some: {name: "Mentor"},
-        roles_none: {name: "Founder"}
+        roles_none: {name: "Founder"},
+        visible
       }
       orderBy: firstName_ASC
     ) {
@@ -41,7 +42,6 @@ const MentorsQuery = gql`
       gitHubUrl
       linkedInUrl
       twitterUrl
-      visible
     }
   }
 `;

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -29,7 +29,7 @@ const MentorsQuery = gql`
       where: {
         roles_some: {name: "Mentor"},
         roles_none: {name: "Founder"},
-        visible
+        visible: true
       }
       orderBy: firstName_ASC
     ) {

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -41,6 +41,7 @@ const MentorsQuery = gql`
       gitHubUrl
       linkedInUrl
       twitterUrl
+      visible
     }
   }
 `;


### PR DESCRIPTION
* add visible field to MentorsQuery

Mentors that are not in draft status, but aren't set to visible are appearing on the website. This adds visible to the MentorsQuery and filters out "invisible" mentors.

**Before**
![image](https://user-images.githubusercontent.com/10378331/114489846-6f277f00-9bd9-11eb-8e01-2dc6093bda91.png)


**After (no more April)**
![image](https://user-images.githubusercontent.com/10378331/114489776-561ece00-9bd9-11eb-8eeb-62456c028dee.png)
