### PR TITLE
Use liquid language for main layout

### DIFF
--- a/pages/_includes/mlayout.liquid
+++ b/pages/_includes/mlayout.liquid
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <title>{% htmlTitle %}</title>
+    <title>{{ htmlTitle }}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
     <link rel="dns-prefetch" href="https://fonts.gstatic.com/">
@@ -29,14 +29,14 @@
   <body>
     <div id="toast" class="toast hidden" role="alert"></div>
     <header>
-      <h1>{% pageTitle %}</h1>
+      <h1>{{ pageTitle }}</h1>
       <nav>
-        {% navigation %}
+        {{ navigation }}
       </nav>
-      {% pageSubTitle %}
+      {{ pageSubTitle }}
     </header>
     <main>
-      {% content %}
+      {{ content }}
     </main>
     <footer>
       <p>Copyright &copy; 2019 – 2022 The Collab Lab. All rights reserved.</p>

--- a/pages/_includes/mlayout.liquid
+++ b/pages/_includes/mlayout.liquid
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <title>{{ htmlTitle }}</title>
+    <title>{% htmlTitle %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
     <link rel="dns-prefetch" href="https://fonts.gstatic.com/">
@@ -29,14 +29,14 @@
   <body>
     <div id="toast" class="toast hidden" role="alert"></div>
     <header>
-      <h1>{{{pageTitle}}}</h1>
+      <h1>{% pageTitle %}</h1>
       <nav>
-        {{{navigation}}}
+        {% navigation %}
       </nav>
-      {{{pageSubTitle}}}
+      {% pageSubTitle %}
     </header>
     <main>
-      {{{ content }}}
+      {% content %}
     </main>
     <footer>
       <p>Copyright &copy; 2019 – 2022 The Collab Lab. All rights reserved.</p>

--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: About Us | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / About
 navigation: <ul> <li>About</li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: Apply | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Apply
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li>Apply</li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>

--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: Code of Conduct | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Code of Conduct
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li>Code of Conduct</li> </ul>

--- a/pages/developers.html
+++ b/pages/developers.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: Developers | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Developers
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Developers</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: The Collab Lab
 pageTitle: The Collab Lab
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>

--- a/pages/mentor.html
+++ b/pages/mentor.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: Mentor | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Mentor
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li>Mentor</li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>

--- a/pages/pages.11tydata.js
+++ b/pages/pages.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  layout: 'mlayout.liquid',
+};

--- a/pages/pages.11tydaya.js
+++ b/pages/pages.11tydaya.js
@@ -1,3 +1,0 @@
-module.exports = {
-  layout: 'mlayout.liquid',
-};

--- a/pages/pages.11tydaya.js
+++ b/pages/pages.11tydaya.js
@@ -1,0 +1,3 @@
+module.exports = {
+  layout: 'mlayout.liquid',
+};

--- a/pages/tech-talks.html
+++ b/pages/tech-talks.html
@@ -1,5 +1,4 @@
 ---
-layout: mlayout.hbs
 htmlTitle: Tech Talks | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Tech Talks
 navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li>Tech Talks</li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>


### PR DESCRIPTION
## Summary
This work unbocks #186. Adding to the navigation as-is requires making changes to each template in `/pages`. We could use Eleventy's [official navigation plugin](https://www.11ty.dev/docs/plugins/navigation/) to DRY up our nav, but it doesn't seem to work in handlebars layouts.

This PR also adds [a directory data file](https://www.11ty.dev/docs/data-template-dir/) at `pages/pages.11tydaya.js`. The object exported there sets the layout for _all_ templates in `pages/`, so we do not need to repeat that key in every template.