### PR TITLE
Create initial volunteer page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,5 @@
+const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
+
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('pages/assets');
   eleventyConfig.addPassthroughCopy('pages/favicon.ico');
@@ -6,6 +8,8 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addPassthroughCopy('_redirects');
+
+  eleventyConfig.addPlugin(eleventyNavigationPlugin);
 
   eleventyConfig.addShortcode(
     'generateSocialMediaLinkLabel',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "stripe": "^8.209.0"
       },
       "devDependencies": {
+        "@11ty/eleventy-navigation": "^0.3.2",
         "@types/stripe-v3": "^3.1.26",
         "eslint": "^8.11.0",
         "eslint-config-prettier": "^8.5.0",
@@ -77,6 +78,19 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-navigation": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-0.3.2.tgz",
+      "integrity": "sha512-7RJdnViAdHtDTVgJBN07+a0G5T4x6IhyjFVHkBhtlasKibsfT7+9j8nnFoJr76ngrUCm1SQ/1P/dS75j6ojVjQ==",
+      "dev": true,
+      "dependencies": {
+        "dependency-graph": "^0.11.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5294,6 +5308,15 @@
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
           "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg=="
         }
+      }
+    },
+    "@11ty/eleventy-navigation": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-navigation/-/eleventy-navigation-0.3.2.tgz",
+      "integrity": "sha512-7RJdnViAdHtDTVgJBN07+a0G5T4x6IhyjFVHkBhtlasKibsfT7+9j8nnFoJr76ngrUCm1SQ/1P/dS75j6ojVjQ==",
+      "dev": true,
+      "requires": {
+        "dependency-graph": "^0.11.0"
       }
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "stripe": "^8.209.0"
   },
   "devDependencies": {
+    "@11ty/eleventy-navigation": "^0.3.2",
     "@types/stripe-v3": "^3.1.26",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",

--- a/pages/_includes/mlayout.liquid
+++ b/pages/_includes/mlayout.liquid
@@ -31,7 +31,7 @@
     <header>
       <h1>{{ pageTitle }}</h1>
       <nav>
-        {{ navigation }}
+        {{ collections.all | eleventyNavigation | eleventyNavigationToHtml }}
       </nav>
       {{ pageSubTitle }}
     </header>

--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: About Us | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / About
-navigation: <ul> <li>About</li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+eleventyNavigation:
+  key: About
+  order: 1
 ---
 
 <h2 id="mission">Our Mission</h2>

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: Apply | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Apply
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li>Apply</li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+eleventyNavigation:
+  key: Apply
+  order: 3
 ---
 
 {{html}}

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -3,7 +3,7 @@ htmlTitle: Apply | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Apply
 eleventyNavigation:
   key: Apply
-  order: 3
+  order: 4
 ---
 
 {{html}}

--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -3,7 +3,7 @@ htmlTitle: Code of Conduct | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Code of Conduct
 eleventyNavigation:
   key: Code of Conduct
-  order: 5
+  order: 7
 ---
 
 <h2>Code of Conduct</h2>

--- a/pages/code-of-conduct.html
+++ b/pages/code-of-conduct.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: Code of Conduct | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Code of Conduct
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li>Code of Conduct</li> </ul>
+eleventyNavigation:
+  key: Code of Conduct
+  order: 5
 ---
 
 <h2>Code of Conduct</h2>

--- a/pages/developers.html
+++ b/pages/developers.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: Developers | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Developers
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li>Developers</li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+eleventyNavigation:
+  key: Developers
+  order: 2
 ---
 
 <h2 id="developers">Developers</h2>

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,7 +1,6 @@
 ---
 htmlTitle: The Collab Lab
 pageTitle: The Collab Lab
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
 pageSubTitle: <h2>Gain <strong>practical experience</strong> by working remotely on<strong> real world projects</strong> with other<strong> early-career developers.</strong></h2>
 ---
 

--- a/pages/mentor.html
+++ b/pages/mentor.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: Mentor | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Mentor
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li>Mentor</li> <li><a href="/tech-talks/">Tech Talks</a></li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+eleventyNavigation:
+  key: Mentor
+  order: 4
 ---
 
 {{html}}

--- a/pages/mentor.html
+++ b/pages/mentor.html
@@ -3,7 +3,7 @@ htmlTitle: Mentor | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Mentor
 eleventyNavigation:
   key: Mentor
-  order: 4
+  order: 5
 ---
 
 {{html}}

--- a/pages/tech-talks.html
+++ b/pages/tech-talks.html
@@ -3,7 +3,7 @@ htmlTitle: Tech Talks | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Tech Talks
 eleventyNavigation:
   key: Tech Talks
-  order: 4
+  order: 6
 ---
 
 <h2>Tech Talks by The Collab Lab</h2>

--- a/pages/tech-talks.html
+++ b/pages/tech-talks.html
@@ -1,7 +1,9 @@
 ---
 htmlTitle: Tech Talks | The Collab Lab
 pageTitle: <a href="/">The Collab Lab</a> / Tech Talks
-navigation: <ul> <li><a href="/about-us/">About</a></li> <li><a href="/developers/">Developers</a></li> <li><a href="/apply/">Apply</a></li> <li><a href="/mentor/">Mentor</a></li> <li>Tech Talks</li> <li><a href="/code-of-conduct/">Code of Conduct</a></li> </ul>
+eleventyNavigation:
+  key: Tech Talks
+  order: 4
 ---
 
 <h2>Tech Talks by The Collab Lab</h2>

--- a/pages/volunteers.html
+++ b/pages/volunteers.html
@@ -1,0 +1,13 @@
+---
+htmlTitle: Volunteers | The Collab Lab
+pageTitle: <a href="/">The Collab Lab</a> / Volunteers
+eleventyNavigation:
+  key: Volunteers
+  order: 3
+---
+
+<h2 id="volunteers">Volunteers</h2>
+<p>
+  The Collab Lab is run by an amazing bunch of volunteers. More info to be
+  added!
+</p>


### PR DESCRIPTION
## Summary
Closes #186 

Uses the [Eleventy navigation plugin](https://www.11ty.dev/docs/plugins/navigation/) to DRY up our repeated site navigation, and adds a new page at `/volunteers`. There's some copy there now to serve as a placeholder, but it should be replaced in subsequent work.