### PR TITLE
Simplify GraphQL data layer

### DIFF
--- a/pages/developers.html
+++ b/pages/developers.html
@@ -65,7 +65,7 @@ teams -%}
 <h2 id="board">Board & Advisors</h2>
 <ul>
   {%- for advisor in advisors -%}
-  <li class="member-container span-3">{{advisor.bio.html}}</li>
+  <li class="member-container span-3">{{advisor.bio}}</li>
   {%- endfor -%}
 </ul>
 {% comment %} START FOUNDERS {% endcomment %}
@@ -94,7 +94,7 @@ teams -%}
       {% endif %} {% endfor %}
     </div>
   </li>
-  <li class="member-container span-3">{{founder.bio.html}}</li>
+  <li class="member-container span-3">{{founder.bio}}</li>
   {%- endfor -%}
 </ul>
 <h2>Get in touch!</h2>

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -116,7 +116,6 @@ const getMentors = async () =>
       if (role === 'Founder') return false;
       if (role === 'Mentor') {
         keep = true;
-        break;
       }
     }
     return keep;
@@ -129,7 +128,6 @@ const getAdvisors = async () =>
       if (role === 'Founder') return false;
       if (role === 'Advisor') {
         keep = true;
-        break;
       }
     }
     return keep;

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -105,14 +105,14 @@ const staff = (async () => {
 })();
 
 const getVolunteers = async () =>
-  (await staff).filter((v) => {
-    return !v.roles.includes('Founder');
+  (await staff).filter((s) => {
+    return !s.roles.includes('Founder');
   });
 
 const getMentors = async () =>
-  (await staff).filter((v) => {
+  (await staff).filter((s) => {
     let keep = false;
-    for (const role of v.roles) {
+    for (const role of s.roles) {
       if (role === 'Founder') return false;
       if (role === 'Mentor') {
         keep = true;
@@ -123,9 +123,9 @@ const getMentors = async () =>
   });
 
 const getAdvisors = async () =>
-  (await staff).filter((v) => {
+  (await staff).filter((s) => {
     let keep = false;
-    for (const role of v.roles) {
+    for (const role of s.roles) {
       if (role === 'Founder') return false;
       if (role === 'Advisor') {
         keep = true;
@@ -136,8 +136,8 @@ const getAdvisors = async () =>
   });
 
 const getFounders = async () =>
-  (await staff).filter((v) => {
-    return v.roles.includes('Founder');
+  (await staff).filter((s) => {
+    return s.roles.includes('Founder');
   });
 
 const getPages = async () => {

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -87,13 +87,20 @@ const getTeams = async () => {
   }
 };
 
+/**
+ * staff are *all* Collabies whose *only* role is not "Paricipant".
+ * This includes Mentors, Founders, Advisors, CoC responders
+ * and former Participants, as long as they have done other things.
+ */
 const staff = (async () => {
   try {
     const { collabies } = await request(graphQLEndpoint, StaffQuery);
     return collabies.map((c) => {
       return {
         ...c,
+        // Flatten the bio prop to just the `html` string
         bio: c.bio?.html,
+        // Flatten the role objects to just their `name` string
         roles: c.roles.map((r) => r.name),
       };
     });
@@ -102,11 +109,14 @@ const staff = (async () => {
   }
 })();
 
+// Get all staff who are not Founders
 const getVolunteers = async () =>
   (await staff).filter((s) => {
     return !s.roles.includes('Founder');
   });
 
+// Get all staff who are not Founders
+// and who have mentored
 const getMentors = async () =>
   (await staff).filter((s) => {
     let keep = false;
@@ -119,6 +129,8 @@ const getMentors = async () =>
     return keep;
   });
 
+// Get all staff who are not Founders
+// and who have served as Advisor
 const getAdvisors = async () =>
   (await staff).filter((s) => {
     let keep = false;
@@ -131,6 +143,7 @@ const getAdvisors = async () =>
     return keep;
   });
 
+// Get all staff who are Founders
 const getFounders = async () =>
   (await staff).filter((s) => {
     return s.roles.includes('Founder');

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -96,13 +96,11 @@ const staff = (async () => {
   try {
     const { collabies } = await request(graphQLEndpoint, StaffQuery);
     return collabies.map((c) => {
-      return {
-        ...c,
-        // Flatten the bio prop to just the `html` string
-        bio: c.bio?.html,
-        // Flatten the role objects to just their `name` string
-        roles: c.roles.map((r) => r.name),
-      };
+      // Flatten the bio prop to just the `html` string
+      c.bio = c.bio?.html;
+      // Flatten the role objects to just their `name` string
+      c.roles = c.roles.map((r) => r.name);
+      return c;
     });
   } catch (e) {
     throw new Error('There was a problem getting Staff', e);

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -81,9 +81,7 @@ const getTeams = async () => {
       teamNumber: calculateTeamNumber(team.anchor),
     }));
 
-    return result
-      .filter((team) => team.visible)
-      .sort((a, b) => b.teamNumber - a.teamNumber);
+    return result.sort((a, b) => b.teamNumber - a.teamNumber);
   } catch (e) {
     throw new Error('There was a problem getting Teams', e);
   }

--- a/pages/graphql/data.js
+++ b/pages/graphql/data.js
@@ -72,7 +72,7 @@ const graphQLEndpoint =
 const getTeams = async () => {
   try {
     const { teams } = await request(graphQLEndpoint, TeamsQuery);
-    const result = teams.map((team) => ({
+    return teams.map((team) => ({
       ...team,
       calculatedDate: calculatedDate({
         startDate: team.startDate,
@@ -80,8 +80,6 @@ const getTeams = async () => {
       }),
       teamNumber: calculateTeamNumber(team.anchor),
     }));
-
-    return result.sort((a, b) => b.teamNumber - a.teamNumber);
   } catch (e) {
     throw new Error('There was a problem getting Teams', e);
   }

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -146,21 +146,20 @@ const FrontPageApplicationBlock = gql`
   }
 `;
 
-const VolunteersQuery = gql`
+const StaffQuery = gql`
   query Volunteers {
     collabies(
-      where: {
-        NOT: { roles_every: { name: "Participant" } }
-        roles_none: { name: "Founder" }
-        visible: true
-      }
+      where: { NOT: { roles_every: { name: "Participant" } }, visible: true }
       orderBy: firstName_ASC
     ) {
-      firstName
-      fullName
+      bio {
+        html
+      }
       roles(where: { name_not: "Participant" }) {
         name
       }
+      firstName
+      fullName
       pathToPhoto
       gitHubUrl
       linkedInUrl
@@ -176,4 +175,4 @@ exports.FoundersQuery = FoundersQuery;
 exports.PagesQuery = PagesQuery;
 exports.TechTalksQuery = TechTalksQuery;
 exports.FrontPageApplicationBlock = FrontPageApplicationBlock;
-exports.VolunteersQuery = VolunteersQuery;
+exports.StaffQuery = StaffQuery;

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -2,7 +2,7 @@ const { gql } = require('graphql-request');
 
 const TeamsQuery = gql`
   query Teams {
-    teams(where: { visible: true }, orderBy: startDate_ASC) {
+    teams(where: { visible: true }, orderBy: startDate_DESC) {
       anchor
       displayName
       startDate

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -22,70 +22,6 @@ const TeamsQuery = gql`
   }
 `;
 
-const MentorsQuery = gql`
-  query GetMentors {
-    collabies(
-      where: {
-        roles_some: { name: "Mentor" }
-        roles_none: { name: "Founder" }
-        visible: true
-      }
-      orderBy: firstName_ASC
-    ) {
-      firstName
-      fullName
-      bio {
-        html
-      }
-      pathToPhoto
-      gitHubUrl
-      linkedInUrl
-      twitterUrl
-    }
-  }
-`;
-
-const AdvisorsQuery = gql`
-  query GetAdvisors {
-    collabies(
-      where: {
-        roles_some: { name: "Advisor" }
-        roles_none: { name: "Founder" }
-      }
-      orderBy: firstName_ASC
-    ) {
-      firstName
-      fullName
-      bio {
-        html
-      }
-      pathToPhoto
-      gitHubUrl
-      linkedInUrl
-      twitterUrl
-    }
-  }
-`;
-
-const FoundersQuery = gql`
-  query GetFounders {
-    collabies(
-      where: { roles_some: { name: "Founder" } }
-      orderBy: firstName_ASC
-    ) {
-      firstName
-      fullName
-      bio {
-        html
-      }
-      pathToPhoto
-      gitHubUrl
-      linkedInUrl
-      twitterUrl
-    }
-  }
-`;
-
 const PagesQuery = gql`
   query GetPages {
     pages {
@@ -168,9 +104,6 @@ const StaffQuery = gql`
 `;
 
 exports.TeamsQuery = TeamsQuery;
-exports.MentorsQuery = MentorsQuery;
-exports.AdvisorsQuery = AdvisorsQuery;
-exports.FoundersQuery = FoundersQuery;
 exports.PagesQuery = PagesQuery;
 exports.TechTalksQuery = TechTalksQuery;
 exports.FrontPageApplicationBlock = FrontPageApplicationBlock;

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -2,7 +2,7 @@ const { gql } = require('graphql-request');
 
 const TeamsQuery = gql`
   query Teams {
-    teams(where: { visible: true }, orderBy: startDate_DESC) {
+    teams(where: { visible: true }, orderBy: startDate_ASC) {
       anchor
       displayName
       startDate

--- a/pages/graphql/queries.js
+++ b/pages/graphql/queries.js
@@ -2,12 +2,11 @@ const { gql } = require('graphql-request');
 
 const TeamsQuery = gql`
   query Teams {
-    teams(orderBy: startDate_DESC) {
+    teams(where: { visible: true }, orderBy: startDate_DESC) {
       anchor
       displayName
       startDate
       endDate
-      visible
       developers: participants(orderBy: firstName_ASC) {
         firstName
         fullName

--- a/pages/volunteers.html
+++ b/pages/volunteers.html
@@ -24,7 +24,7 @@ eleventyNavigation:
     class="volunteer__roles"
   >
   {%- for role in volunteer.roles -%}
-    <li class="volunteer__roles-item">{{role.name}}</li>
+    <li class="volunteer__roles-item">{{role}}</li>
   {%- endfor -%}
   </ul>
   {%- endcapture -%}


### PR DESCRIPTION
## Summary
This PR improves our build time by replacing multiple distinct GraphQL Collabie queries with _one_ query. In order to render the right Collabies in the right places, we filter this larger amount of data locally. 

Local filtering is technically™ more work on the local machine, but it's a negligible amount of "more" – build times are as much as 50% faster by not making these extra network requests.

The `Teams` query is also changed: by filtering for visible teams only, we do not need to filter in our application layer; and the sort operation we previously did is also unnecessary, I think?

## Test plan
1. Open [the deploy preview](https://deploy-preview-197--the-collab-lab.netlify.app/)
2. Navigate to the Developers page
3. Ensure that we see the Collabies we expect (a bunch of collections of Teams, sorted most-recent to oldest; then our founders)
4. Navigate to the Volunteers page
5. Ensure that we see the Collabies we expect (an unstyled list of volunteers)