### PR TITLE
Fix some styles

### DIFF
--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -7,7 +7,7 @@
 
 :root {
   --page-width: 1146px;
-  --base-font-size: 16px;
+  --base-font-size: 1rem;
   --small-font-size: 85%;
 }
 
@@ -15,13 +15,15 @@ body {
   background: white;
   color: black;
   font: var(--base-font-size) / 1.5 'Source Sans Pro', Sans-Serif;
+  margin: 0;
 }
 
 header,
 main,
 footer {
+  max-width: 95%;
+  width: var(--page-width);
   margin: 1rem auto;
-  max-width: var(--page-width);
 }
 
 header {
@@ -245,10 +247,6 @@ figure.float-right figcaption {
 /* small screens */
 /* under 820px wide, adjust margins, fix the footer and tweak how we display the carousel */
 @media screen and (max-width: 819px) {
-  body {
-    margin: auto 20px;
-    width: 100%;
-  }
   header h1 {
     padding-top: 1rem;
   }

--- a/pages/assets/volunteers.css
+++ b/pages/assets/volunteers.css
@@ -1,24 +1,34 @@
+figure {
+  margin: 0;
+}
+
 .volunteer-gallery {
   display: grid;
-  grid-template-columns: 100%;
+  grid-column-gap: 2em;
+  grid-row-gap: 2em;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   justify-items: center;
   margin: auto;
 }
 
+.volunteer-grid-item {
+  max-width: 300px;
+}
+
 .volunteer {
   border: 1px solid #e5e5e5;
-  width: 300px;
+  padding-bottom: 0.5em;
 }
 .volunteer > figcaption {
   display: grid;
   grid-template-rows: auto 1fr auto;
   align-items: center;
-  justify-items: center;  
+  justify-items: center;
   height: 150px;
 }
 .volunteer__photo {
   height: 300px;
-  width: 300px;
+  width: auto;
 }
 .volunteer__name {
   display: block;
@@ -59,18 +69,4 @@
   height: 2rem;
   width: 2rem;
   margin: 0.25rem;
-}
-
-@media screen and (min-width: 768px) {
-  .volunteer-gallery {
-    width: 750px;
-    grid-template-columns: repeat(2, 50%);
-  }
-}
-
-@media screen and (min-width: 1230px) {
-  .volunteer-gallery {
-    width: 1146px;
-    grid-template-columns: repeat(3, 33%);
-  }
 }

--- a/pages/volunteers.html
+++ b/pages/volunteers.html
@@ -16,7 +16,8 @@ eleventyNavigation:
 {%- for volunteer in volunteers -%}
 {%- assign firstName = volunteer.firstName -%}
 {%- assign fullName = volunteer.fullName -%}
-{%- assign volunteerPhotoUrl = volunteer.pathToPhoto -%}
+{%- assign volunteerPhotoPath = volunteer.pathToPhoto |
+  '/assets/img/members/generic-avatar.png' %}
 
 {%- capture rolesListHtml -%}
   <ul
@@ -40,6 +41,7 @@ eleventyNavigation:
     {%- assign siteUrl = volunteer[urlProp] -%}
 
       {%- if siteUrl.length > 0 -%}
+      {%- capture siteIconPath -%} /assets/img/icons/{{site}}.png {%- endcapture -%}
         <li class="volunteer__social-item">
           <a
             href="{{siteUrl}}"
@@ -48,7 +50,7 @@ eleventyNavigation:
             <img
               alt=""
               classList="icon"
-              src="/assets/img/icons/{{site}}.png"
+              src="{{ siteIconPath | url }}"
             />
           </a>
         </li>
@@ -58,19 +60,14 @@ eleventyNavigation:
   {%- endcapture -%}
   <div class="volunteer-grid-item">
     <figure class="volunteer">
-      {%- if volunteerPhotoUrl -%}
       <img
         alt=""
         class="volunteer__photo"
-        src="{{volunteerPhotoUrl}}"
+        loading="lazy"
+        height="300"
+        src="{{ volunteerPhotoPath | url }}"
+        width="300"
       >
-      {%- else -%}
-      {%- assign placeholderStyles = 'width:300px;height:300px;background-color:royalblue;'-%}
-      <div
-        class="volunteer__photo"
-        style="{{placeholderStyles}}"
-      ></div>
-      {%- endif -%}
       <figCaption>
         <b class="volunteer__name">{{fullName}}</b>
         {{rolesListHtml}}

--- a/pages/volunteers.html
+++ b/pages/volunteers.html
@@ -86,16 +86,3 @@ eleventyNavigation:
 
 {% comment %} Render the grid items we built above. {% endcomment %}
 <div class="volunteer-gallery">{{gridItems}}</div>
-<script>
-  // If a volunteer photo fails to load, swap it in-place
-  // for one of our placeholders
-  document.addEventListener('error', function(evt) {
-    const el = evt.target;
-    if (el.matches('.volunteer__photo')) {
-      const placeholder = document.createElement('div');
-      placeholder.style.cssText = '{{placeholderStyles}}';
-
-      el.parentElement.replaceChild(placeholder, el);
-    }
-  }, true);
-  </script>


### PR DESCRIPTION
## Summary
This PR:
- ensures that the `body` element is properly constrained to the viewport, preventing cutoff text (see [changes section](#visual-changes)
- simplifies the CSS for the volunteers grid
- cleans up the volunteers page template

## Visual changes
Text was cut off on every page – this is just one example
| Before                                                                                                                          | After                                                                                                                     |
|---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
| ![the-collab-lab codes_](https://user-images.githubusercontent.com/13525251/162554118-efc7f559-2533-44fe-b30a-2758c8eb9fef.png) | ![localhost_8080_](https://user-images.githubusercontent.com/13525251/162554182-8c36260f-5042-48ae-9200-13044dd3a5d5.png) |

## Test plan
1. Visit [the deploy preview](https://deploy-preview-207--the-collab-lab.netlify.app/)
2. Verify that things look good