### PR TITLE
Add an application banner to the top of the pages

### DIFF
--- a/pages/_includes/mlayout.liquid
+++ b/pages/_includes/mlayout.liquid
@@ -26,6 +26,7 @@
   </head>
   <body>
     <div id="toast" class="toast hidden" role="alert"></div>
+    {{ applicationBanner }}
     <header>
       <h1>{{ pageTitle }}</h1>
       <nav>

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -239,6 +239,11 @@ figure.float-right figcaption {
   max-width: 360px;
 }
 
+.banner > blockquote {
+  margin: 0;
+  text-align: center;
+}
+
 .flex {
   display: flex;
   align-items: center;

--- a/pages/pages.11tydata.js
+++ b/pages/pages.11tydata.js
@@ -1,3 +1,9 @@
+const { getFrontPageApplicationBlock } = require('./graphql/data');
+
 module.exports = {
   layout: 'mlayout.liquid',
+  applicationBanner: async () => {
+    const block = await getFrontPageApplicationBlock();
+    return `<div class="banner">${block.textBlocks[0].textContent.html}</div>`
+  }
 };


### PR DESCRIPTION
**Description**

This PR displays the next cohort start date as a banner at the top of all pages.

**Closes** #213 

**Note**: Wasn't sure if we should remove the blockquote related to the application start date on the main page or not.

**How it looks**

<img width="1698" alt="banner" src="https://user-images.githubusercontent.com/43115763/164985241-c36b5342-6c3d-41f4-997e-56a2a9f9df05.png">

