### PR TITLE
style/Show volunteer roles in collapsible menu

### DIFF
--- a/pages/assets/img/icons/minus.svg
+++ b/pages/assets/img/icons/minus.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20px" height="20px" viewBox="0 0 20 20" version="1.1">
+<g id="surface1">
+<path style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(22.352941%,21.568627%,27.45098%);stroke-opacity:1;stroke-miterlimit:4;" d="M 31 16 C 31 24.28125 24.28125 31 16 31 C 7.71875 31 1 24.28125 1 16 C 1 7.71875 7.71875 1 16 1 C 24.28125 1 31 7.71875 31 16 Z M 31 16 " transform="matrix(0.625,0,0,0.625,0,0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(22.352941%,21.568627%,27.45098%);fill-opacity:1;" d="M 15 9.375 L 15 10.625 L 5 10.625 L 5 9.375 Z M 15 9.375 "/>
+</g>
+</svg>

--- a/pages/assets/img/icons/plus.svg
+++ b/pages/assets/img/icons/plus.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20px" height="20px" viewBox="0 0 20 20" version="1.1">
+<g id="surface1">
+<path style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(22.352941%,21.568627%,27.45098%);stroke-opacity:1;stroke-miterlimit:4;" d="M 31 16 C 31 24.28125 24.28125 31 16 31 C 7.71875 31 1 24.28125 1 16 C 1 7.71875 7.71875 1 16 1 C 24.28125 1 31 7.71875 31 16 Z M 31 16 " transform="matrix(0.625,0,0,0.625,0,0)"/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(22.352941%,21.568627%,27.45098%);fill-opacity:1;" d="M 9.375 5 L 10.625 5 L 10.625 15 L 9.375 15 Z M 9.375 5 "/>
+<path style=" stroke:none;fill-rule:nonzero;fill:rgb(22.352941%,21.568627%,27.45098%);fill-opacity:1;" d="M 15 9.375 L 15 10.625 L 5 10.625 L 5 9.375 Z M 15 9.375 "/>
+</g>
+</svg>

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -26,6 +26,7 @@
   --page-width: 1146px;
   --base-font-size: 1rem;
   --small-font-size: 85%;
+  --main-color: #393746;
 }
 
 body {

--- a/pages/assets/volunteer.css
+++ b/pages/assets/volunteer.css
@@ -1,3 +1,41 @@
+.roles {
+  border-top: 1px solid var(--main-color);
+}
+
+.roles__details {
+  border-bottom: 1px solid var(--main-color);
+  padding: 10px;
+}
+
+.roles__details > p {
+  padding-left: 27px;
+}
+
+.roles__details summary {
+  color: var(--main-color);
+  font-size: 1.1rem;
+  font-weight: bold;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+}
+
+summary:before {
+  content: url('./img/icons/plus.svg');
+  display: block;
+  margin-top: 8px;
+  margin-right: 8px;
+}
+
+details[open] summary:before {
+  content: url('./img/icons/minus.svg');
+}
+
+summary::-webkit-details-marker {
+  display: none
+}
+
 figure {
   margin: 0;
 }

--- a/pages/volunteer.html
+++ b/pages/volunteer.html
@@ -79,51 +79,69 @@ eleventyNavigation:
 {%- endfor -%}
 {%- endcapture -%}
 
-<h2 id="roles">What our volunteers do</h2>
+<h2>Volunteer at The Collab Lab!</h2>
 <p>
   The Collab Lab is run by an amazing bunch of volunteers that do different things to keep the lights on.
 </p>
+<div class="roles">
+  <details class="roles__details">
+    <summary>Project Team Mentors</summary>
+    <p>
+      These folks are professional engineers who spend 8 weeks leading teams of early-career engineers through building an
+      app on a software development team, hosting 1-hour weekly synchronous meetings each weekend, holding office hours to
+      assist developers, participating in code reviews, and presenting learning modules.
+    </p>
+    <p>
+      <b>Commitment</b>: ~5 hours/week for 10 weeks
+    </p>
+    <p> Ready to do this? Tell us about you through our <a href="https://airtable.com/shr8rMObHvknZ0nZ0">mentor
+      application form!</a>
+    </p>
+  </details>
 
-<h3>Project Team Mentors</h3>
-<p>
-  These folks are professional engineers who spend 8 weeks leading teams of early-career engineers through building an
-  app on a software development team, hosting 1-hour weekly synchronous meetings each weekend, holding office hours to
-  assist developers, participating in code reviews, and presenting learning modules.
-</p>
-<p>
-  Commitment: ~5 hours/week for 10 weeks
-</p>
-<p> Ready to do this? Tell us about you through our <a href="https://airtable.com/shr8rMObHvknZ0nZ0">mentor
-  application form!</a></p>
+  <details class="roles__details">
+    <summary>Career Lab Volunteers</summary>
+    <p>
+      Each quarter, we run Career Lab, a 2-week extension on the core Collab Lab project where our Collabies get the
+      opportunity to optimize their Linkedin and practice mock job fit and technical with folks who are interviewing
+      engineers every day in their respective roles. These folks take time to coach our Collabies through the job hunt and
+      interview process.
+    </p>
+    <p>
+      <b>Commitment</b>: ~5 hours per week for 2 weeks
+    </p> 
+  </details>
 
-<h3>Career Lab Volunteers</h3>
-<p>
-  Each quarter, we run Career Lab, a 2-week extension on the core Collab Lab project where our Collabies get the
-  opportunity to optimize their Linkedin and practice mock job fit and technical with folks who are interviewing
-  engineers every day in their respective roles. These folks take time to coach our Collabies through the job hunt and
-  interview process.
-</p>
-<p>
-  Commitment: ~5 hours per week for 2 weeks
-</p>
+  <details class="roles__details">
+    <summary>Automation Heroes</summary>
+    <p>
+      Behind the scenes of The Collab Lab, our Automation Heroes build automations to help us be more efficient in doing the
+      work to keep the lights on for our programs. They write scripts to automate team setup, ensure all the teams' projects
+      are up to date, and maintain our website with GraphCMS, 11ty, and Netlify.
+    </p>
+  </details>
 
-<h3>Automation heroes</h3>
+  <details class="roles__details">
+    <summary>Community Managers</summary>
+    <p>
+      These folks keep our community engaged and growing! They organize and host our Tech Talk series, manage our social
+      media, and keep our internal channels poppin' with fun and helpful events and conversations. 
+    </p>
+  </details>
+
+  <details class="roles__details">
+    <summary>Code of Conduct Team</summary>
+    <p> 
+      At the Collab Lab, we;re dedicated to creating and maintaining an inclusive and psychologically safe space for
+      everyone in our community to learn and grow in. Our Code of Conduct responders are professionally trained and
+      ensure everyone in our community is upholding the commitment to our Code of Conduct.
+    </p>
+  </details>
+</div>
 <p>
-  Behind the scenes of The Collab Lab, our Automation Heroes build automations to help us be more efficient in doing the
-  work to keep the lights on for our programs. They write scripts to automate team setup, ensure all the teams’ projects
-  are up to date, and maintain our website with GraphCMS, 11ty, and Netlify.</p>
-
-<h3>Community managers</h3>
-<p>These folks keep our community engaged and growing! They organize and host our Tech Talk series, manage our social
-  media, and keep our internal channels poppin’ with fun and helpful events and conversations. </p>
-<h3>Code of Conduct team</h3>
-<p> At the Collab Lab, we’re dedicated to creating and maintaining an inclusive and psychologically safe space for
-  everyone in our community to learn and grow in. Our Code of Conduct responders are professionally trained and
-  ensure everyone in our community is upholding the commitment to our Code of Conduct.
+  Still not sure whether volunteering for The Collab Lab is a good fit for you? Please don't hesitate to email Andrew
+  at <a href="mailto:andrew@the-collab-lab.codes">andrew@the-collab-lab.codes</a> to get your questions answered.
 </p>
-
-<p>Still not sure whether volunteering for The Collab Lab is a good fit for you? Please don’t hesitate to email Andrew
-  at <a href="mailto:andrew@the-collab-lab.codes">andrew@the-collab-lab.codes</a> to get your questions answered.</p>
 
 <h2 id="volunteers">Our volunteers</h2>
 


### PR DESCRIPTION
**Description**

This PR shows the volunteer types/roles as a collapsible menu using [the details disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).

Closes #217 

**How it looks**

<img width="1721" alt="volunteer" src="https://user-images.githubusercontent.com/43115763/166138871-103dcfbd-cbb1-464f-b348-f45407a1c3ea.png">
