### PR TITLE
Update style colors

### DIFF
--- a/pages/about-us.html
+++ b/pages/about-us.html
@@ -6,7 +6,7 @@
     the code reviews, retrospectives, and pair programming sessions. So thankful
     for the program and the supportive mentors who make it happen!</q
   >
-  <span class="hang-it"
+  <span class="q__attribute"
     >~<a href="https://twitter.com/Mindy_Joy">Mindy Zwanziger</a>, Associate
     Software Engineer at <a href="https://newrelic.com/">New Relic</a></span
   >

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -29,7 +29,7 @@
   --main-color: #2b373b;
   --neutral-color: whitesmoke;
   --neutral-dark-color: #ccc;
-  --accent-color: #cf5c36;
+  --accent-color: #e88d67;
   --link-color: #0075f2;
 }
 
@@ -39,6 +39,7 @@ body {
   font: var(--base-font-size) / 1.5 'Source Sans Pro', Sans-Serif;
   margin: 0;
   font-weight: 300;
+  overflow-x: hidden;
 }
 
 header,
@@ -46,6 +47,13 @@ main {
   max-width: 95%;
   width: var(--page-width);
   margin: 1rem auto;
+}
+
+.roles__details > p,
+.tech-talks > li,
+main li,
+main > p {
+  max-width: 92ch;
 }
 
 header {
@@ -65,6 +73,7 @@ header nav {
   position: absolute;
   right: 0;
   top: -2rem;
+  font-size: 1.1rem;
 }
 header nav ul {
   list-style: none;
@@ -178,14 +187,6 @@ footer .copyright {
   margin: 0;
   padding: 0;
 }
-/*
-.copyright p:first-child {
-  float: left;
-}
-.copyright p:last-child {
-  text-align: right;
-}
-*/
 
 h3 {
   margin-bottom: 0.5rem;
@@ -195,7 +196,7 @@ h3 {
 blockquote {
   background: var(--main-color);
   color: var(--neutral-color);
-  margin: 1.5rem -1rem;
+  margin: 2.5rem -1rem;
   padding: 1rem 2rem;
 }
 blockquote p,
@@ -210,21 +211,27 @@ footer a:hover, blockquote a:hover {
   border-bottom: solid 1px var(--neutral-color);
 }
 
-.hang-it {
+.q__attribute {
   display: inline-block;
-  margin-left: -0.5rem;
+  float: right;
+  background: var(--main-color);
+  padding: 0.3rem 0.7rem;
+  border-radius: 2px;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
 q {
   display: block;
   position: relative;
+  padding: 1.2rem;
+  border-right: 2px solid var(--accent-color);
 }
 q::before {
   color: var(--neutral-dark-color);
   content: '“';
   font-size: xx-large;
   font-weight: bold;
-  left: -1.1rem;
+  left: -0.9rem;
   position: absolute;
   top: -0.36rem;
 }

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -39,7 +39,6 @@ body {
   font: var(--base-font-size) / 1.5 'Source Sans Pro', Sans-Serif;
   margin: 0;
   font-weight: 300;
-  overflow-x: hidden;
 }
 
 header,
@@ -214,11 +213,6 @@ footer a:hover, blockquote a:hover {
 
 .q__attribute {
   display: inline-block;
-  float: right;
-  background: var(--main-color);
-  padding: 0.3rem 0.7rem;
-  border-radius: 2px;
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
 q {
@@ -477,7 +471,11 @@ figure img {
 /* under 820px wide, adjust margins, fix the footer and tweak how we display the carousel */
 @media screen and (max-width: 819px) {
   header h1 {
-    padding-top: 1rem;
+    padding-top: 2rem;
+  }
+
+  header nav {
+    font-size: 1rem;
   }
 
   footer {
@@ -487,6 +485,10 @@ figure img {
 
   .testimonials-container {
     border: 0;
+  }
+
+  .testimonials-container svg {
+    left: 100px;
   }
 
   .stats-p{

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -163,6 +163,7 @@ footer > * {
 }
 
 footer h2 {
+  color: var(--accent-color);
   font-size: 2rem;
 }
 

--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -26,12 +26,16 @@
   --page-width: 1146px;
   --base-font-size: 1rem;
   --small-font-size: 85%;
-  --main-color: #393746;
+  --main-color: #2b373b;
+  --neutral-color: whitesmoke;
+  --neutral-dark-color: #ccc;
+  --accent-color: #cf5c36;
+  --link-color: #0075f2;
 }
 
 body {
-  background: white;
-  color: var(--main-color);
+  background: var(--neutral-color);
+  color: black;
   font: var(--base-font-size) / 1.5 'Source Sans Pro', Sans-Serif;
   margin: 0;
   font-weight: 300;
@@ -46,6 +50,7 @@ main {
 
 header {
   position: relative;
+  color: var(--main-color);
 }
 header h1 {
   font-size: 2.5rem;
@@ -89,7 +94,7 @@ header nav ul li:last-child:after {
 
 .testimonials-container {
   min-height: 400px;
-  border-right: 1px solid white;
+  border-right: 1px solid var(--neutral-color);
 }
 
 .testimonials-container > div{
@@ -102,20 +107,20 @@ header nav ul li:last-child:after {
   font-size: 2.5rem;
   border: none;
   background: transparent;
-  color: white;
+  color: var(--neutral-color);
 }
 
 .testimonials-container svg {
   position: relative;
   left: 175px;
   top: 25px;
-  color: #ccc;
+  color: var(--neutral-dark-color);
   width: 32px;
   height: auto;
 }
 
 .testimonials-container svg:hover {
-  color: white;
+  color: var(--neutral-color);
 }
 
 .testimonial {
@@ -139,7 +144,7 @@ header nav ul li:last-child:after {
 
 footer {
   background: var(--main-color);
-  color: white;
+  color: var(--neutral-color);
   display: flex;
   padding: 4rem 1rem;
 }
@@ -189,7 +194,7 @@ h3 {
 
 blockquote {
   background: var(--main-color);
-  color: white;
+  color: var(--neutral-color);
   margin: 1.5rem -1rem;
   padding: 1rem 2rem;
 }
@@ -198,11 +203,11 @@ blockquote dl {
   margin: 0;
 }
 footer a, blockquote a {
-  color: #ccc;
+  color: var(--neutral-dark-color);
 }
 footer a:hover, blockquote a:hover {
-  color: white;
-  border-bottom: solid 1px white;
+  color: var(--neutral-color);
+  border-bottom: solid 1px var(--neutral-color);
 }
 
 .hang-it {
@@ -215,7 +220,7 @@ q {
   position: relative;
 }
 q::before {
-  color: silver;
+  color: var(--neutral-dark-color);
   content: '“';
   font-size: xx-large;
   font-weight: bold;
@@ -243,17 +248,17 @@ h2 {
 }
 
 a {
-  color: blue;
+  color: var(--link-color);
   text-decoration: none;
 }
 a:hover {
-  border-bottom: solid 1px blue;
+  border-bottom: solid 1px var(--link-color);
 }
 
 hr {
   border-style: solid;
   border-width: 1px;
-  color: silver;
+  color: var(--neutral-dark-color);
 }
 
 figure.float-right {
@@ -287,12 +292,12 @@ figure img {
   padding: 0;
 }
 .tech-talks > li {
-  border-bottom: solid 1px #ccc;
+  border-bottom: solid 1px var(--neutral-dark-color);
   margin: 1rem 0;
   padding-bottom: 1rem;
 }
 .tech-talks > li:first-child {
-  border-top: solid 1px #ccc;
+  border-top: solid 1px var(--neutral-dark-color);
 }
 .tech-talks h3 {
   margin: 1.5rem 0;
@@ -337,7 +342,7 @@ figure img {
   width: 130px;
   font-size: 1.2rem;
   font-weight: bold;
-  padding-top: 20px; 
+  padding-top: 20px;
 }
 
 .stats-graphs img {
@@ -369,13 +374,13 @@ figure img {
 }
 
 .block {
-  background-color: #393746;
+  background-color: var(--main-color);
   display: block;
   height: 35px;
   margin: 0 10px;
 }
 
-.block-270px { 
+.block-270px {
   width: 270px;
 }
 
@@ -450,7 +455,7 @@ figure img {
 }
 
 .icons {
-  fill: white;
+  fill: var(--neutral-color);
   width: 22px;
   height: auto;
   padding-right: 1.2rem;

--- a/pages/index.html
+++ b/pages/index.html
@@ -139,8 +139,8 @@ pageSubTitle: <h2>Gain <strong>practical experience</strong> by working remotely
       without being able to talk about my experience with pair programming and
       resolving merge conflicts. Beyond that, I made some great friends!</q
     >
-    <span class="hang-it"
-      >~<a href="https://caitlyngreffly.com">Caitlyn Greffly</a>, Software Engineer at
+    <span class="q__attribute"
+      >~ <a href="https://caitlyngreffly.com">Caitlyn Greffly</a>, Software Engineer at
       <a href="https://www.fool.com">The Motley Fool</a></span
     >
   </blockquote>

--- a/pages/volunteer.html
+++ b/pages/volunteer.html
@@ -109,7 +109,7 @@ eleventyNavigation:
     </p>
     <p>
       <b>Commitment</b>: ~5 hours per week for 2 weeks
-    </p> 
+    </p>
   </details>
 
   <details class="roles__details">
@@ -125,13 +125,13 @@ eleventyNavigation:
     <summary>Community Managers</summary>
     <p>
       These folks keep our community engaged and growing! They organize and host our Tech Talk series, manage our social
-      media, and keep our internal channels poppin' with fun and helpful events and conversations. 
+      media, and keep our internal channels poppin' with fun and helpful events and conversations.
     </p>
   </details>
 
   <details class="roles__details">
     <summary>Code of Conduct Team</summary>
-    <p> 
+    <p>
       At the Collab Lab, we;re dedicated to creating and maintaining an inclusive and psychologically safe space for
       everyone in our community to learn and grow in. Our Code of Conduct responders are professionally trained and
       ensure everyone in our community is upholding the commitment to our Code of Conduct.
@@ -146,12 +146,12 @@ eleventyNavigation:
 <h2 id="volunteers">Our volunteers</h2>
 
 <blockquote>
-  <p>As a mentor, I work to give Collab Lab cohorts the experience of building and deploying a production app on a
+  <q>As a mentor, I work to give Collab Lab cohorts the experience of building and deploying a production app on a
     high-performing, psychologically safe team using the same principles and practices that have helped me be successful
     as a professional engineering manager. Our participants learn firsthand how powerful and effective a healthy,
     functional team is. With this experience as a reference point, they leave empowered to advocate for themselves,
     their colleagues, and ready to transform organizations for the better.
-  <p>- <a href="http://leadingwithspoons.com/">Adrienne Lowe, Collab Lab Mentor</a></p>
+  </q><span class="q__attribute">~ <a href="https://leadingwithspoons.com/">Adrienne Lowe, Collab Lab Mentor</a></span>
 </blockquote>
 
 {% comment %} Render the grid items we built above. {% endcomment %}


### PR DESCRIPTION
Hi friends! 

### In this branch:

1. created a set of css variables representing a complete website color scheme, set them to reasonable default values, and replaced instances of those colors with the variables. 
2. did some light restyling, including updating the <q> tag and its attribute (in order to use the accent color, for demo purposes), I made the nav links slightly larger, and set a max width of 92 characters for some of the larger blocks of text (for ease of reading).

### Example screenshots
#### Before:
<img width="1263" alt="Screen Shot 2022-07-15 at 5 04 49 PM" src="https://user-images.githubusercontent.com/68952706/179326095-8266ca40-effc-40ad-bb75-5bbf5c0a15d9.png">

#### After:
<img width="1245" alt="Screen Shot 2022-07-15 at 5 04 31 PM" src="https://user-images.githubusercontent.com/68952706/179326107-d8f74c62-94d2-4304-9861-a4bcebb33f7f.png">


### Seeking review:

- default color values need a second (and maybe third?) opinion. 
- is the max-width of 92ch too heavy of a hammer? I find the full width length of texts hard to follow, but that might be too personal of an opinion and removing it might be a better, more universal option. 
- anything else anyone can think of.

closes #235 