### PR TITLE
Adjust the testimonial pause button on mobile

### DIFF
--- a/pages/assets/styles.css
+++ b/pages/assets/styles.css
@@ -135,6 +135,7 @@ header nav ul li:last-child:after {
   text-align: center;
   width: 90%;
   margin: auto;
+  overflow-wrap: anywhere;
 }
 
 .testimonial img {
@@ -488,7 +489,7 @@ figure img {
   }
 
   .testimonials-container svg {
-    left: 100px;
+    left: 75px;
   }
 
   .stats-p{


### PR DESCRIPTION
A couple simple fixes In this branch:

- used `overflow-wrap: anywhere` to ensure long words line break on mobile
- moved the pause button closer to the center on small screens

Next steps:

- test on a few different devices