### PR TITLE
bug/Modify images paths

### DIFF
--- a/pages/assets/styles/volunteer.css
+++ b/pages/assets/styles/volunteer.css
@@ -22,14 +22,14 @@
 }
 
 summary:before {
-  content: url('./img/icons/plus.svg');
+  content: url('../img/icons/plus.svg');
   display: block;
   margin-top: 8px;
   margin-right: 8px;
 }
 
 details[open] summary:before {
-  content: url('./img/icons/minus.svg');
+  content: url('../img/icons/minus.svg');
 }
 
 summary::-webkit-details-marker {


### PR DESCRIPTION
**This PR fixes broken paths for a couple of icons on the volunteer's page.**

<img width="1337" alt="Screen Shot 2022-07-29 at 3 58 02 PM" src="https://user-images.githubusercontent.com/43115763/181776200-2771d536-6e06-497a-a64b-eabd51742745.png">

