### PR TITLE
fix: add /apply to _redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -2,3 +2,4 @@
 # @see: https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
 
   /who-we-are              /developers
+  /apply                   /participate


### PR DESCRIPTION
a user on twitter pointed out that `/apply` now 404s. this pr causes that route (which is in a bunch of our historical tweets) to redirect to `/participate`