### PR TITLE
Update Documentation for the Site

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,16 +1,22 @@
+// https://www.11ty.dev/docs/config/
 const eleventyNavigationPlugin = require('@11ty/eleventy-navigation');
 
 module.exports = function (eleventyConfig) {
+  // Used to copy additional files that are not page templates
+  // https://www.11ty.dev/docs/copy/
   eleventyConfig.addPassthroughCopy('pages/assets');
   eleventyConfig.addPassthroughCopy('pages/favicon.ico');
   eleventyConfig.addPassthroughCopy({
     'pages/google657107b6feadb517.html': 'google657107b6feadb517.html',
   });
-
   eleventyConfig.addPassthroughCopy('_redirects');
 
+  // Used for creating infinite-depth hierarchical navigation
+  // https://www.11ty.dev/docs/plugins/navigation/
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
 
+  // https://www.11ty.dev/docs/shortcodes/
+  // Used to extend template engines with custom functions
   eleventyConfig.addShortcode(
     'generateSocialMediaLinkLabel',
     function (name, platform) {

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ build
 
 # Local Netlify folder
 .netlify
+
+# GraphQL config files
+schema.graphql
+.graphqlconfig
+graphql.config.json

--- a/README.md
+++ b/README.md
@@ -1,17 +1,152 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d419806f-0315-41c6-917a-52167ab9902c/deploy-status)](https://app.netlify.com/sites/the-collab-lab/deploys)
 
-# website
+# 🖥 The Collab Lab Website
 
-Source repo for the website at https://the-collab-lab.codes
+The source repository for [The Collab Lab website](https://the-collab-lab.codes/).
 
-# Website V2
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li>
+      <a href="#🛠-built-with">🛠 Built With</a>
+    </li>
+    <li>
+      <a href="#📝-getting-started">📝 Getting Started</a>
+      <ul>
+        <li>
+          <a href="#prerequisites">Prerequisites</a>
+        </li>
+        <li>
+          <a href="#installation">Installation</a>
+        </li>
+        <li>
+          <a href="#graphql-introspection">GraphQL</a>
+          <ul>
+            <li>
+              <a href="#vs-code">VS Code</a>
+            </li>
+            <li>
+              <a href="#intellij">IntelliJ</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <a href="#🔬-usage">🔬 Usage</a>
+    </li>
+    <li>
+      <a href="#✨-contributing">✨Contributing</a>
+      <ul>
+        <li>
+          <a href="#how-to-fork-the-project">How to Fork the Project</a>
+        </li>
+      </ul>
+    </li>
+  </ol>
+</details>
 
-- This project uses [11ty](https://www.11ty.dev/), a static site generator like Gatsby or Next.js, but it's a lot simpler and doesn't have a dependency on React.
+## 🛠 Built With
 
-## Scripts to run the project
+- ⚡️ [11ty](https://www.11ty.dev/) - Static Site Generator built on top of various HTML template engines
+- 💧 [Liquid](https://shopify.github.io/liquid/) - Open source templating language
+- 📡 [GraphQL](https://www.graphql.com/) - Data Querying from our CMS
+- 💵 [Stripe](https://stripe.com/docs/api?lang=node) - Processing payments for donations
+- 🖥 [Netlify](https://www.netlify.com/) - Continuous Deployment / Integration
+
+## 📝 Getting Started
+
+### Prerequisites
+
+This website requires Node and NPM to be installed in order to run locally. You can view [this documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) to learn more about installation.
+
+You may also need the [Netlify CLI](https://cli.netlify.com/) to test certain features such as the Stripe donation buttons. If you need access to Netlify, you can request access in [#committee-website](https://the-collab-lab.slack.com/archives/CUS0DJ614) and someone will invite you to the Netlify project.
+
+### Installation
+
+Clone the website using [Github CLI](https://cli.github.com/).
+
+```shell
+gh repo clone the-collab-lab/website
+```
+
+Run `npm i` in the repository directory to install all the necessary packages and to set up [Husky](https://typicode.github.io/husky/#/) for pre-commit linting.
+
+### GraphQL Introspection
+
+Use [this link](https://api-us-east-1.graphcms.com/v2/ckfwosu634r7l01xpco7z3hvq/master) to access the playground and schema for our GraphQL endpoint.
+
+Depending on your IDE, you may have the ability to introspect the schema and unlock type checking in your editor:
+
+#### VS Code
+
+1. Install both the [GraphQL for VSCode](https://marketplace.visualstudio.com/items?itemName=kumar-harsh.graphql-for-vscode) and [GraphQL: Language Feature Support](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) plugins.
+2. Create a `graphql.config.json` and copy/paste the json found below.
+3. VSCode will automatically introspect the schema without having to create a schema file.
+
+#### IntelliJ
+
+1. Install the [GraphQL Plugin](https://plugins.jetbrains.com/plugin/8097-graphql).
+2. Create a `.graphqlconfig` file and copy/paste the json found below.
+3. Use the GraphQL plugin to generate a `schema.graphql` file from the config.
+
+The JSON config for either VS Code's or IntelliJ's config file is:
+
+```json
+{
+  "name": "Collab Lab GraphQL Schema",
+  "schemaPath": "schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "Default GraphQL Endpoint": {
+        "url": "https://api-us-east-1.graphcms.com/v2/ckfwosu634r7l01xpco7z3hvq/master",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": true
+      }
+    }
+  }
+}
+```
+
+For other platforms, consult the documentation for your IDE.
+
+## 🔬 Usage
+
+- All of our queries and data fetching methods can be found in `pages/graphql`.
+- The `src/_data` directory is used to create variables and pass data to the `*.liquid` files.
+- The `src/assets` is where all of our JavaScript, stylesheets, image assets, fonts, and other asset files can be found.
+- The `src/_includes` hosts the main layout file (defined in `src/pages.11tydata.json`) along with any additional reusable templates.
+- All of the `src/*.11tydata.js` files are used to create variables and pass data to the `src/*.html` files, which generate the different pages on the site.
+
+To run the site:
+
+```shell
+npm run dev # starts the dev server on port 8080
+```
+
+To build the site:
 
 ```
-npm run dev # starts the dev server on port 8080
 npm run build # builds the site and outputs it in the /build/ folder
+```
+
+To build and run the build version of the site:
+
+```
 npm run build:serve # builds and serves the site in localhost:5000
 ```
+
+## ✨Contributing
+
+Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are greatly appreciated.
+
+If you have a suggestion that would make this better, please [fork the repo](https://github.com/the-collab-lab/website/fork) and create a pull request, or [create a new issue](https://github.com/the-collab-lab/website/issues)!
+
+### How to Fork the Project
+1. Fork the repository with [this link](https://github.com/the-collab-lab/website/fork) or with the "Fork" button at the top of the repository page
+2. Create your feature branch (git checkout -b feature/AmazingFeature)
+3. Commit your changes (git commit -m 'Add some AmazingFeature')
+4. Push to the branch (git push origin feature/AmazingFeature)
+5. Open a pull request, using your repository and branch as the source, and the `main` branch of this repo as the base.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
       <a href="#-usage">🔬 Usage</a>
     </li>
     <li>
-      <a href="#-contributing">✨Contributing</a>
+      <a href="#contributing">✨Contributing</a>
       <ul>
         <li>
           <a href="#how-to-fork-the-project">How to Fork the Project</a>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
       <a href="#-usage">🔬 Usage</a>
     </li>
     <li>
-      <a href="#contributing">✨Contributing</a>
+      <a href="#-contributing">✨Contributing</a>
       <ul>
         <li>
           <a href="#how-to-fork-the-project">How to Fork the Project</a>
@@ -138,7 +138,7 @@ To build and run the build version of the site:
 npm run build:serve # builds and serves the site in localhost:5000
 ```
 
-## ✨Contributing
+## ✨ Contributing
 
 Contributions are what make the open source community such an amazing place to learn, inspire, and create. Any contributions you make are greatly appreciated.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
   <summary>Table of Contents</summary>
   <ol>
     <li>
-      <a href="#🛠-built-with">🛠 Built With</a>
+      <a href="#-built-with">🛠 Built With</a>
     </li>
     <li>
-      <a href="#📝-getting-started">📝 Getting Started</a>
+      <a href="#-getting-started">📝 Getting Started</a>
       <ul>
         <li>
           <a href="#prerequisites">Prerequisites</a>
@@ -33,10 +33,10 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
       </ul>
     </li>
     <li>
-      <a href="#🔬-usage">🔬 Usage</a>
+      <a href="#-usage">🔬 Usage</a>
     </li>
     <li>
-      <a href="#✨-contributing">✨Contributing</a>
+      <a href="#-contributing">✨Contributing</a>
       <ul>
         <li>
           <a href="#how-to-fork-the-project">How to Fork the Project</a>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
 
 ### Prerequisites
 
-This website requires Node and NPM to be installed in order to run locally. You can view [this documentation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) to learn more about installation.
+This website requires Node and NPM to be installed in order to run locally. You can view the NPM documentation to [learn more about installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
 You may also need the [Netlify CLI](https://cli.netlify.com/) to test certain features such as the Stripe donation buttons. If you need access to Netlify, you can request access in [#committee-website](https://the-collab-lab.slack.com/archives/CUS0DJ614) and someone will invite you to the Netlify project.
 
@@ -75,7 +75,7 @@ Run `npm i` in the repository directory to install all the necessary packages an
 
 ### GraphQL Introspection
 
-Use [this link](https://api-us-east-1.graphcms.com/v2/ckfwosu634r7l01xpco7z3hvq/master) to access the playground and schema for our GraphQL endpoint.
+Use this link to [access the playground and schema for our GraphQL endpoint](https://api-us-east-1.graphcms.com/v2/ckfwosu634r7l01xpco7z3hvq/master).
 
 Depending on your IDE, you may have the ability to introspect the schema and unlock type checking in your editor:
 
@@ -129,13 +129,13 @@ npm run dev # starts the dev server on port 8080
 
 To build the site:
 
-```
+```shell
 npm run build # builds the site and outputs it in the /build/ folder
 ```
 
 To build and run the build version of the site:
 
-```
+```shell
 npm run build:serve # builds and serves the site in localhost:5000
 ```
 
@@ -146,8 +146,8 @@ Contributions are what make the open source community such an amazing place to l
 If you have a suggestion that would make this better, please [fork the repo](https://github.com/the-collab-lab/website/fork) and create a pull request, or [create a new issue](https://github.com/the-collab-lab/website/issues)!
 
 ### How to Fork the Project
-1. Fork the repository with [this link](https://github.com/the-collab-lab/website/fork) or with the "Fork" button at the top of the repository page
-2. Create your feature branch (git checkout -b feature/AmazingFeature)
-3. Commit your changes (git commit -m 'Add some AmazingFeature')
-4. Push to the branch (git push origin feature/AmazingFeature)
+1. Use this link to [fork the repository](https://github.com/the-collab-lab/website/fork) or use the “Fork” button at the top of the repository page
+2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+4. Push to the branch (`git push origin feature/AmazingFeature`)
 5. Open a pull request, using your repository and branch as the source, and the `main` branch of this repo as the base.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The source repository for [The Collab Lab website](https://the-collab-lab.codes/
 
 - ⚡️ [11ty](https://www.11ty.dev/) - Static Site Generator built on top of various HTML template engines
 - 💧 [Liquid](https://shopify.github.io/liquid/) - Open source templating language
+- 📚 [Hygraph](https://hygraph.com/) (Previously GraphCMS) - Content management
 - 📡 [GraphQL](https://www.graphql.com/) - Data Querying from our CMS
 - 💵 [Stripe](https://stripe.com/docs/api?lang=node) - Processing payments for donations
 - 🖥 [Netlify](https://www.netlify.com/) - Continuous Deployment / Integration


### PR DESCRIPTION
This PR resolves #248 and adds more detailed documentation to the `README.md` file. It also updates the `.gitignore` to prevent GraphQL configs from being added to the project in case someone would like to use that, and adds a few comments about how 11ty is set up on the site to build pages.