### PR TITLE
Default project mentors section to open

### DIFF
--- a/pages/volunteer.html
+++ b/pages/volunteer.html
@@ -84,7 +84,7 @@ eleventyNavigation:
   The Collab Lab is run by an amazing bunch of volunteers that do different things to keep the lights on.
 </p>
 <div class="roles">
-  <details class="roles__details">
+  <details class="roles__details" open>
     <summary>Project Team Mentors</summary>
     <p>
       These folks are professional engineers who spend 8 weeks leading teams of early-career engineers through building an


### PR DESCRIPTION
I send people to [our Volunteer page](https://the-collab-lab.codes/volunteer/) on the regular to tell them to apply to be a project mentor, but if they don’t know that that’s what we call it they sometimes miss opening the `<details>` element for that role, leaving them unable to find the application form. This change opens that first blurb by default making it easier for potential mentors to apply for the program.