### PR TITLE
Add a link to our Mastodon

### DIFF
--- a/pages/_includes/get-in-touch.liquid
+++ b/pages/_includes/get-in-touch.liquid
@@ -1,7 +1,7 @@
 <h2>Get in touch!</h2>
 <ul>
   <li>
-    <svg version="1.1" id="icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+    <svg version="1.1" class="icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
        viewBox="0 0 173.1 185.6" style="enable-background:new 0 0 173.1 185.6;" xml:space="preserve">
     <style type="text/css">
       .st0{fill:#FFFFFF;}

--- a/pages/_includes/get-in-touch.liquid
+++ b/pages/_includes/get-in-touch.liquid
@@ -1,7 +1,7 @@
 <h2>Get in touch!</h2>
 <ul>
   <li>
-    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+    <svg version="1.1" id="icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
        viewBox="0 0 173.1 185.6" style="enable-background:new 0 0 173.1 185.6;" xml:space="preserve">
     <style type="text/css">
       .st0{fill:#FFFFFF;}

--- a/pages/_includes/get-in-touch.liquid
+++ b/pages/_includes/get-in-touch.liquid
@@ -1,6 +1,25 @@
 <h2>Get in touch!</h2>
 <ul>
   <li>
+    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+       viewBox="0 0 173.1 185.6" style="enable-background:new 0 0 173.1 185.6;" xml:space="preserve">
+    <style type="text/css">
+      .st0{fill:#FFFFFF;}
+    </style>
+    <path class="st0" d="M173.1,60.9c0-40.3-26.4-52.1-26.4-52.1C133.4,2.8,110.6,0.2,86.9,0h-0.6C62.6,0.2,39.7,2.8,26.4,8.9
+      c0,0-26.4,11.8-26.4,52.1c0,9.2-0.2,20.2,0.1,31.9c1,39.4,7.2,78.2,43.6,87.8c16.8,4.4,31.2,5.4,42.8,4.7c21-1.2,32.9-7.5,32.9-7.5
+      l-0.7-15.3c0,0-15,4.7-31.9,4.2c-16.7-0.6-34.4-1.8-37.1-22.4c-0.2-1.8-0.4-3.7-0.4-5.8c0,0,16.4,4,37.3,5
+      c12.7,0.6,24.7-0.7,36.8-2.2c23.3-2.8,43.5-17.1,46-30.2C173.5,90.6,173.1,60.9,173.1,60.9z M142,112.8h-19.3V65.5
+      c0-10-4.2-15-12.6-15c-9.3,0-13.9,6-13.9,17.9v25.9H77V68.3c0-11.9-4.7-17.9-13.9-17.9c-8.4,0-12.6,5.1-12.6,15v47.3H31.1V64.1
+      c0-10,2.5-17.9,7.6-23.7c5.3-5.9,12.1-8.9,20.7-8.9c9.9,0,17.4,3.8,22.3,11.4l4.8,8.1l4.8-8.1c4.9-7.6,12.4-11.4,22.3-11.4
+      c8.5,0,15.4,3,20.7,8.9c5.1,5.9,7.6,13.8,7.6,23.7V112.8z"/>
+    </svg>
+    <span>
+      The Collab Lab is on Mastodon
+      <a rel="me" href="https://techhub.social/@CollabLab">@CollabLab@techhub.social</a>
+    </span>
+  </li>
+  <li>
     <svg version="1.1" class="icons" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 248 204" style="enable-background:new 0 0 248 204;" xml:space="preserve" aria-hidden="true">
       <path id="white_background" class="st0" d="M221.95,51.29c0.15,2.17,0.15,4.34,0.15,6.53c0,66.73-50.8,143.69-143.69,143.69v-0.04
               C50.97,201.51,24.1,193.65,1,178.83c3.99,0.48,8,0.72,12.02,0.73c22.74,0.02,44.83-7.61,62.72-21.66
@@ -11,7 +30,7 @@
     </svg>
     <span>
       The Collab Lab is on Twitter
-      <a href="https://twitter.com/_collab_lab">@_collab_lab</a>. 
+      <a href="https://twitter.com/_collab_lab">@_collab_lab</a>.
     </span>
   </li>
   <li>
@@ -20,7 +39,7 @@
     </svg>
     <span>
       We post periodic updates about the program on
-      <a href="https://dev.to/the-collab-lab">our dev.to channel</a>. 
+      <a href="https://dev.to/the-collab-lab">our dev.to channel</a>.
     </span>
   </li>
   <li>


### PR DESCRIPTION
This PR adds a link to our shiny, new Mastodon account. The link includes the `rel="me"` attribute so our website will show up as verified on Mastodon.

## Before

<img width="500" alt="screenshot showing the get in touch section of the footer with twitter, dev.to, and email links" src="https://user-images.githubusercontent.com/4306/202836785-aa12e897-394e-4bb3-9814-6ecf904f3e9b.png">

## After

<img width="503" alt="screenshot showing the get in touch section of the footer with mastodon, twitter, dev.to, and email links" src="https://user-images.githubusercontent.com/4306/202836791-a4c99f3a-309e-4c4d-b629-6560c4828c4d.png">


