### PR TITLE
Bug fix: Display application questions on /participate

### DIFF
--- a/pages/participate.11tydata.js
+++ b/pages/participate.11tydata.js
@@ -2,7 +2,7 @@ const { getPages } = require('./graphql/data');
 
 module.exports = async () => {
   const pages = await getPages();
-  const filtered = pages.filter((page) => '/apply/' === page.slug);
+  const filtered = pages.filter((page) => '/participate/' === page.slug);
   let html = filtered.length > 0 ? filtered[0].html : '';
 
   return {


### PR DESCRIPTION
## Bug: 

No application questions are appearing on the `participate` page. [Reported in Slack thread [here](https://the-collab-lab.slack.com/archives/CUS0DJ614/p1670341996386289)]

## Fix: 

Ensure the `participate.11tydata.js ` is filtering for the `participate` page rather than the old `apply` page. 

## Expected results: 

Application questions appear on the `/participate` page 
